### PR TITLE
V3

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ and importing them via YAML or JSON files or by just passing an object
   - `client.updatePet(1, payload)`
 - [x] Built on top of the robust [axios](https://github.com/axios/axios) JavaScript library
 - [x] Isomorphic, works both in browser and Node.js
-- [ ] Generate TypeScript definitions (.d.ts) for your APIs with full IntelliSense support
+- [x] Generate TypeScript definitions (.d.ts) for your APIs with full IntelliSense support
 
 ## Quick Start
 
@@ -119,6 +119,39 @@ override axios request config parameters, such as `headers`, `timeout`, `withCre
 // POST /user - createUser
 client.createUser(null, { user: 'admin', pass: '123' }, { headers: { 'x-api-key': 'secret' } });
 ```
+
+## Generating types for clients
+
+`openapi-client-axios` comes with a tool called `typegen` to generate typescript type files (.d.ts) for 
+OpenAPIClient instances using an OpenAPI definition.
+
+```
+Usage: typegen [file]
+
+Options:
+  --help     Show help                                                 [boolean]
+  --version  Show version number                                       [boolean]
+
+Examples:
+  typegen ./openapi.yml > client.d.ts  - generate a type definition file
+```
+
+The output of `typegen` exports a type called `Client`, which can be used for instances of `OpenAPIClient`;
+
+```typescript
+import { Client } from './client.d.ts';
+
+const client = await api.init<Client>();
+```
+
+Both the `api.getClient()` and `api.init()` methods support passing in a Client type.
+
+````typescript
+import { Client as PetStoreClient } from './client.d.ts';
+
+const client = await api.init<PetStoreClient>();
+const client = await api.getClient<PetStoreClient>();
+````
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@ JavaScript client library for consuming OpenAPI-enabled APIs with [axios](https:
 
 - [x] Create API clients by describing them in [OpenAPI specification](https://github.com/OAI/OpenAPI-Specification)
 and importing them via YAML or JSON files or by just passing an object
-- [x] Call API operations with your preferred syntax:
-  - `client.updatePet(1, pet)` - operation methods
-  - `client.query('updatePet', 1, pet)` - query method
-  - `client.put('/pets/1', pet)` - axios method aliases
-  - `client({ method: 'put', url: '/pets/1', data: pet })` - axios basic
+- [x] Easy to use API to call API operations using JavaScript methods
+  - `client.getPet(1)`
+  - `client.searchPets()`
+  - `client.searchPets({ ids: [1, 2, 3] })`
+  - `client.updatePet(1, payload)`
 - [x] Built on top of the robust [axios](https://github.com/axios/axios) JavaScript library
 - [x] Isomorphic, works both in browser and Node.js
-- [x] Option to mock API backends using [openapi-backend](https://github.com/anttiviljami/openapi-backend)
-- [x] TypeScript types included
+- [ ] Generate TypeScript definitions (.d.ts) for your APIs with full IntelliSense support
 
 ## Quick Start
 
@@ -47,117 +46,66 @@ const api = new OpenAPIClientAxios({ definition: 'https://example.com/api/openap
 api.init();
 
 async function createPet() {
-  const res = await api.client.createPet({ name: 'Garfield' });
+  const res = await api.client.createPet(null, { name: 'Garfield' });
   console.log('Pet created', res.data);
 }
 ```
 
-## Calling API operations
+# Operation methods
 
-After initalizing `OpenAPIClientAxios`, an axios instance extended with OpenAPI capabilities is exposed.
-
-Example:
-```javascript
-const api = new OpenAPIClientAxios({ definition: 'https://example.com/api/openapi.json' });
-api.init().then((client) => {
-  // ...
-});
-```
-
-The exposed `client` is an [axios instance](https://github.com/axios/axios#creating-an-instance) initalized with
-baseURL from OpenAPI definitions and extended with extra methods for calling API operations.
-
-There are four different ways to call API operations:
-
-1. `client.updatePet(1, pet)` - operation methods
-2. `client.query('updatePet', 1, pet)` - query method
-3. `client.put('/pets/1', pet)` - axios method aliases
-4. `client({ method: 'put', url: '/pets/1', data: pet })` - axios basic
-
-Example:
-```javascript
-const api = new OpenAPIClientAxios({
-  definition: {
-    openapi: '3.0.1',
-    info: {
-      title: 'Petstore',
-      version: '1.0.0',
-    },
-    servers: [{ url: 'http://localhost:9000' }], // petstore api
-    paths: {
-      '/pets': {
-        get: {
-          operationId: 'getPets',
-          responses: {
-            200: { description: 'ok' },
-          },
-        },
-      },
-    },
-  },
-});
-
-async function test() {
-  const client = await api.init();
-
-  const res1 = await client.getPets();
-  const res2 = await client.query('getPets');
-  const res3 = await client.get('/pets');
-  const res4 = await client({ method: 'get', url: '/pets' });
-
-  assert.deepEqual(res1.data, res2.data);
-  assert.deepEqual(res1.data, res3.data);
-  assert.deepEqual(res1.data, res4.data);
-}
-test();
-```
-
-## Operation methods
-
-OpenAPIClientAxios operation methods take in 3 types of arguments:
+OpenAPIClientAxios operation methods take 3 arguments:
 
 ```javascript
-client.operationId(pathParams?, data?, config?)
+client.operationId(parameters?, data?, config?)
 ```
 
-### Path params
+### Parameters
 
-The first argument is the path parameters for the operation.
+The first argument is used to pass parameters available for the operation.
+
+```javascript
+// GET /pets/{petId}/owner?id={ownerId} - getPetOwner
+client.getPetOwner({ petId: '1', ownerId: '2' })
+```
+
+For syntactic sugar purposes, you can also specify a single implicit parameter value, in which case OpenAPIClientAxios
+will look for the first required parameter for the operation. Usually this is will be a path parameter.
 
 ```javascript
 // GET /pets/{petId} - getPet
-client.getPet(petId)
+client.getPet(1)
 ```
 
-If the operation requires more than a single path parameter, use an object or an array.
-
-Note that when using an array, the parameters should be in the same order as they appear in the path template of the
-operation.
+Alternatively, you can explicitly specify parameters in array form. This method allows you to set custom parameters not defined 
+in the OpenAPI spec.
 
 ```javascript
-// GET /pets/{petId}/owner/{ownerId} - getPetOwner
-client.getPetOwner({ petId, ownerId })
-// or
-client.getPetOwner([petId, ownerId])
+// GET /pets?search=Garfield - searchPets
+client.searchPets([{ name: 'search', value: 'Garfield', in: 'query' }])
 ```
 
-If no path parameters are required for the operation, the first argument is the data / payload argument (next section).
+The type of the parameters can be any of:
+- query
+- header
+- path
+- cookie
 
-### Data / Payload
+### Payload
 
-The next argument the path parameters is the data argument. This allows you to send request body payloads with your
-API call.
+The second argument is used to pass the requestPayload
 
 ```javascript
 // PUT /pets/1 - updatePet
 client.updatePet(1, { name: 'Odie' })
 ```
 
-If there are no path parameters for the operation, the data argument will be the first argument.
+More complex payloads, such as Node.js streams or FormData supported by Axios are also supported.
+
+The first argument can be set to null if there are no parameters required for the operation.
 
 ```javascript
 // POST /pets - createPet
-client.createPet({ name: 'Garfield' })
+client.updatePet(null, { name: 'Garfield' })
 ```
 
 ### Config object
@@ -165,21 +113,12 @@ client.createPet({ name: 'Garfield' })
 The last argument is the config object.
 
 The config object is an [`AxiosRequestConfig`](https://github.com/axios/axios#request-config) object. You can use it to
-override axios request config parameters, such as `headers`, `params`, `timeout`, `withCredentials` and many more.
+override axios request config parameters, such as `headers`, `timeout`, `withCredentials` and many more.
 
 ```javascript
-// PUT /pets/1?fields=name - updatePet
-client.updatePet(1, { name: 'Odie' }, { params: { fields: 'name' } });
+// POST /user - createUser
+client.createUser(null, { user: 'admin', pass: '123' }, { headers: { 'x-api-key': 'secret' } });
 ```
-
-If there are no path or data parameters for the operation, the config argument will be the first argument.
-
-```javascript
-// GET /pets?query=dog - searchPets
-client.searchPets({ params: { query: 'dog' } });
-```
-
-Any arguments passed after the config object will cause OpenAPI backend to throw an Error.
 
 ## Contributing
 

--- a/bin/typegen
+++ b/bin/typegen
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+require('../typegen').main();

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,54 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@anttiviljami/dtsgenerator": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@anttiviljami/dtsgenerator/-/dtsgenerator-2.0.7.tgz",
+      "integrity": "sha512-IF7UfmScs/r+HUPLLog424i22DLm/hpJY3CNNImPyLwMawGuKuf0331X+rzu/OSHIcAPUxQV/WfGVvVfUBD68g==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.20.0",
+        "cross-fetch": "^3.0.2",
+        "debug": "^4.1.1",
+        "glob": "^7.1.3",
+        "js-yaml": "^3.13.1",
+        "mkdirp": "^0.5.1",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.20.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
+          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+          "dev": true
+        },
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "js-yaml": {
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
+        }
+      }
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
@@ -63,6 +111,21 @@
       "version": "2.0.15",
       "resolved": "https://registry.npmjs.org/@types/swagger-schema-official/-/swagger-schema-official-2.0.15.tgz",
       "integrity": "sha512-ZQKcczZbsfVKf+QKViMvjGni1BADoWCjnimkUc3l4zV/d0sM4cj+Hbtg9gjwUaPhi4m3Q8ne62B+fYubUIPqZQ==",
+      "dev": true
+    },
+    "@types/yargs": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.0.tgz",
+      "integrity": "sha512-hY0o+kcz9M6kH32NUeb6VURghqMuCVkiUx+8Btsqhj4Hhov/hVGUx9DmBJeIkzlp1uAQK4wngQBCjqWdUUkFyA==",
+      "dev": true,
+      "requires": {
+        "@types/yargs-parser": "*"
+      }
+    },
+    "@types/yargs-parser": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-wBlsw+8n21e6eTd4yVv8YD/E3xq0O6nNnJIquutAsFGE7EyMKz7W6RNT6BRu1SmdgmlCZ9tb0X+j+D6HGr8pZw==",
       "dev": true
     },
     "abab": {
@@ -1105,6 +1168,16 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1223,13 +1296,25 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
-    "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+    "cross-fetch": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.0.2.tgz",
+      "integrity": "sha512-a4Z0EJ5Nck6QtMy9ZqloLfpvu2uMV3sBfMCR+CgSBCZc6z5KR4bfEiD3dkepH8iZgJMXQpTqf8FjMmvu/GMFkg==",
       "dev": true,
       "requires": {
-        "lru-cache": "^4.0.1",
+        "node-fetch": "2.3.0",
+        "whatwg-fetch": "3.0.0"
+      }
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
         "shebang-command": "^1.2.0",
         "which": "^1.2.9"
       }
@@ -1437,6 +1522,21 @@
         "safer-buffer": "^2.1.0"
       }
     },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -1524,13 +1624,13 @@
       }
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
+      "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
       "dev": true,
       "requires": {
-        "cross-spawn": "^5.0.1",
-        "get-stream": "^3.0.0",
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^4.0.0",
         "is-stream": "^1.1.0",
         "npm-run-path": "^2.0.0",
         "p-finally": "^1.0.0",
@@ -2313,16 +2413,19 @@
       "dev": true
     },
     "get-caller-file": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
     },
     "get-stream": {
-      "version": "3.0.0",
-      "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-      "dev": true
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+      "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
+      "requires": {
+        "pump": "^3.0.0"
+      }
     },
     "get-value": {
       "version": "2.0.6",
@@ -2619,6 +2722,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -2645,9 +2754,9 @@
       }
     },
     "invert-kv": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
       "dev": true
     },
     "is-accessor-descriptor": {
@@ -3031,6 +3140,50 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
         "jest-cli": {
           "version": "23.6.0",
           "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-23.6.0.tgz",
@@ -3073,6 +3226,73 @@
             "strip-ansi": "^4.0.0",
             "which": "^1.2.12",
             "yargs": "^11.0.0"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "11.1.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+              "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+              "dev": true,
+              "requires": {
+                "cliui": "^4.0.0",
+                "decamelize": "^1.1.1",
+                "find-up": "^2.1.0",
+                "get-caller-file": "^1.0.1",
+                "os-locale": "^2.0.0",
+                "require-directory": "^2.1.1",
+                "require-main-filename": "^1.0.1",
+                "set-blocking": "^2.0.0",
+                "string-width": "^2.0.0",
+                "which-module": "^2.0.0",
+                "y18n": "^3.2.1",
+                "yargs-parser": "^9.0.2"
+              }
+            }
+          }
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "mem": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
           }
         },
         "strip-ansi": {
@@ -3082,6 +3302,21 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -3327,11 +3562,150 @@
         "yargs": "^11.0.0"
       },
       "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        },
+        "execa": {
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w==",
+          "dev": true
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "^1.0.0"
+          }
+        },
+        "mem": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+          "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+          "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+          "dev": true,
+          "requires": {
+            "execa": "^0.7.0",
+            "lcid": "^1.0.0",
+            "mem": "^1.1.0"
+          }
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+          "dev": true,
+          "requires": {
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^4.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^3.0.0"
+          }
+        },
         "strip-bom": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
           "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
           "dev": true
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
+          "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+          "dev": true,
+          "requires": {
+            "cliui": "^4.0.0",
+            "decamelize": "^1.1.1",
+            "find-up": "^2.1.0",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^9.0.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "9.0.2",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
+          "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
         }
       }
     },
@@ -3555,12 +3929,12 @@
       }
     },
     "lcid": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+      "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
       "dev": true,
       "requires": {
-        "invert-kv": "^1.0.0"
+        "invert-kv": "^2.0.0"
       }
     },
     "left-pad": {
@@ -3662,9 +4036,9 @@
       }
     },
     "lru-cache": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
-      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
       "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
@@ -3684,6 +4058,15 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.x"
+      }
+    },
+    "map-age-cleaner": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
+      "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
+      "requires": {
+        "p-defer": "^1.0.0"
       }
     },
     "map-cache": {
@@ -3742,12 +4125,14 @@
       "dev": true
     },
     "mem": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
+      "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
       "dev": true,
       "requires": {
-        "mimic-fn": "^1.0.0"
+        "map-age-cleaner": "^0.1.1",
+        "mimic-fn": "^2.0.0",
+        "p-is-promise": "^2.0.0"
       }
     },
     "merge": {
@@ -3802,9 +4187,9 @@
       }
     },
     "mimic-fn": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
-      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
     "minimatch": {
@@ -3907,6 +4292,18 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "node-fetch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+      "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA==",
       "dev": true
     },
     "node-int64": {
@@ -4134,14 +4531,14 @@
       "dev": true
     },
     "os-locale": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
-      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
+      "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
       "dev": true,
       "requires": {
-        "execa": "^0.7.0",
-        "lcid": "^1.0.0",
-        "mem": "^1.1.0"
+        "execa": "^1.0.0",
+        "lcid": "^2.0.0",
+        "mem": "^4.0.0"
       }
     },
     "os-tmpdir": {
@@ -4150,10 +4547,22 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
       "dev": true
     },
+    "p-defer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
+    },
+    "p-is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
       "dev": true
     },
     "p-limit": {
@@ -4374,6 +4783,16 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
       "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ==",
       "dev": true
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "punycode": {
       "version": "2.1.1",
@@ -5365,28 +5784,29 @@
       }
     },
     "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
       "dev": true,
       "requires": {
+        "emoji-regex": "^7.0.1",
         "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^4.0.0"
+        "strip-ansi": "^5.1.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
         },
         "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^3.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -5937,6 +6357,12 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
+      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==",
+      "dev": true
+    },
     "whatwg-mimetype": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.2.0.tgz",
@@ -6040,9 +6466,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
       "dev": true
     },
     "yallist": {
@@ -6052,32 +6478,91 @@
       "dev": true
     },
     "yargs": {
-      "version": "11.1.0",
-      "resolved": "http://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
-      "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
+      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
       "dev": true,
       "requires": {
         "cliui": "^4.0.0",
-        "decamelize": "^1.1.1",
-        "find-up": "^2.1.0",
-        "get-caller-file": "^1.0.1",
-        "os-locale": "^2.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^2.0.1",
+        "os-locale": "^3.1.0",
         "require-directory": "^2.1.1",
-        "require-main-filename": "^1.0.1",
+        "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
-        "string-width": "^2.0.0",
+        "string-width": "^3.0.0",
         "which-module": "^2.0.0",
-        "y18n": "^3.2.1",
-        "yargs-parser": "^9.0.2"
+        "y18n": "^4.0.0",
+        "yargs-parser": "^13.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^3.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "dev": true,
+          "requires": {
+            "p-try": "^2.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^2.0.0"
+          }
+        },
+        "p-try": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+          "dev": true
+        }
       }
     },
     "yargs-parser": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
-      "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
+      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
       "dev": true,
       "requires": {
-        "camelcase": "^4.1.0"
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "dependencies": {
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        }
       }
     },
     "z-schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -101,18 +101,6 @@
       "integrity": "sha512-ugTb7Lq7u4GfWSqqpwE0bGyoBZNMTok/zDBXxfEG0QM50jNlGhIWjRC1pPN7bvV1anhF+bs+/gNcRw+o55Evbg==",
       "dev": true
     },
-    "ajv": {
-      "version": "6.9.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.9.2.tgz",
-      "integrity": "sha512-4UFy0/LgDo7Oa/+wOAlj44tp9K78u38E5/359eSrqEp1Z5PdVfimCcs7SluXMP755RUQu6d2b4AvF0R1C9RZjg==",
-      "dev": true,
-      "requires": {
-        "fast-deep-equal": "^2.0.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
     "ansi-escapes": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
@@ -573,6 +561,7 @@
       "version": "1.16.0",
       "resolved": "https://registry.npmjs.org/axios-mock-adapter/-/axios-mock-adapter-1.16.0.tgz",
       "integrity": "sha512-m2D8ngMTQ5p4zZNBsPKoENgwz5rDfd0pZmXI/spdE2eeeKIcR3jquk+NRiBVFtb9UJlciBYplNzSUmgQ6X385Q==",
+      "dev": true,
       "requires": {
         "deep-equal": "^1.0.1"
       }
@@ -887,12 +876,6 @@
           "dev": true
         }
       }
-    },
-    "bath": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bath/-/bath-2.1.1.tgz",
-      "integrity": "sha512-Tj8bry+Ukr9NVs/WucK6lIQOZxDjppVi9cRdeCz3opJLn1MRZ6EPLkyKHwphz13vHI0bI1nFZd1+H0p7/XJNTg==",
-      "dev": true
     },
     "bath-es5": {
       "version": "2.1.3",
@@ -1223,12 +1206,6 @@
         "safe-buffer": "~5.1.1"
       }
     },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
-      "dev": true
-    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -1323,13 +1300,13 @@
     "decode-uri-component": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-      "dev": true
+      "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
     },
     "deep-equal": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.0.1.tgz",
-      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU="
+      "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1650,12 +1627,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "dev": true
-    },
-    "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
       "dev": true
     },
     "fast-json-stable-stringify": {
@@ -3525,12 +3496,6 @@
         }
       }
     },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -3887,16 +3852,6 @@
         "minimist": "0.0.8"
       }
     },
-    "mock-json-schema": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/mock-json-schema/-/mock-json-schema-1.0.5.tgz",
-      "integrity": "sha512-ZqkT1hbATZrL79B/eOoe8oWesX8QaykFOaMb8hnGVeDZy2Iw1JOtObS8nC4UpFbAk1DpXRrj3zjv63hbhAPKiA==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.11",
-        "openapi-types": "^1.3.2"
-      }
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -4123,31 +4078,6 @@
       "integrity": "sha512-jQ31cORBFE6td25deYeD80wxKBMj+zBmHTrVxnc6CKhx8gho6ipmWM5zj/oeoqioZ99yqBls9Z/9Nss7J26G2g==",
       "requires": {
         "format-util": "^1.0.3"
-      }
-    },
-    "openapi-backend": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/openapi-backend/-/openapi-backend-2.1.0.tgz",
-      "integrity": "sha512-PfcskPeSPh5ea9Y+Siqe/x9R1PDPgRSoHzGctzoi2mjtFDZVVmI6orFg1k1UM2MHS/AbFGVtl4QPbB+mZgo1+g==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.9.2",
-        "bath": "^2.1.1",
-        "cookie": "^0.3.1",
-        "lodash": "^4.17.11",
-        "mock-json-schema": "^1.0.5",
-        "openapi-schema-validation": "^0.4.2",
-        "openapi-types": "^1.3.4",
-        "qs": "^6.6.0",
-        "swagger-parser": "^6.0.5"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.6.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.6.0.tgz",
-          "integrity": "sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==",
-          "dev": true
-        }
       }
     },
     "openapi-schema-validation": {
@@ -4456,6 +4386,16 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
+    },
+    "query-string": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.5.0.tgz",
+      "integrity": "sha512-TYC4hDjZSvVxLMEucDMySkuAS9UIzSbAiYGyA9GWCjLKB8fQpviFbjd20fD7uejCDxZS+ftSdBKE6DS+xucJFg==",
+      "requires": {
+        "decode-uri-component": "^0.2.0",
+        "split-on-first": "^1.0.0",
+        "strict-uri-encode": "^2.0.0"
+      }
     },
     "randomatic": {
       "version": "3.1.1",
@@ -5323,6 +5263,11 @@
       "integrity": "sha512-TfOfPcYGBB5sDuPn3deByxPhmfegAhpDYKSOXZQN81Oyrrif8ZCodOLzK3AesELnCx03kikhyDwh0pfvvQvF8w==",
       "dev": true
     },
+    "split-on-first": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-1.1.0.tgz",
+      "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
+    },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
@@ -5386,6 +5331,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
+    },
+    "strict-uri-encode": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz",
+      "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
     },
     "string-length": {
       "version": "2.0.0",
@@ -5874,15 +5824,6 @@
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
           "dev": true
         }
-      }
-    },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
       }
     },
     "urix": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "2.4.0",
   "author": "Viljami Kuosmanen <viljami@avoinsorsa.fi>",
   "license": "MIT",
+  "bin": {
+    "typegen": "./bin/typegen"
+  },
   "keywords": [
     "openapi",
     "swagger",
@@ -45,11 +48,14 @@
     "swagger-parser": "^6.0.5"
   },
   "devDependencies": {
+    "@anttiviljami/dtsgenerator": "^2.0.7",
     "@types/jest": "^23.3.14",
     "@types/lodash": "^4.14.121",
     "@types/node": "^10.12.29",
     "@types/swagger-parser": "^4.0.3",
+    "@types/yargs": "^13.0.0",
     "axios-mock-adapter": "^1.16.0",
+    "indent-string": "^4.0.0",
     "jest": "^23.6.0",
     "markdown-toc": "^1.2.0",
     "prettier": "^1.16.4",
@@ -57,7 +63,8 @@
     "ts-jest": "^23.10.5",
     "tslint": "^5.13.1",
     "tslint-microsoft-contrib": "^5.2.1",
-    "typescript": "^3.3.3333"
+    "typescript": "^3.3.3333",
+    "yargs": "^13.2.2"
   },
   "scripts": {
     "build": "tsc",

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
   ],
   "dependencies": {
     "axios": "^0.18.0",
-    "axios-mock-adapter": "^1.16.0",
     "bath-es5": "^2.1.3",
     "lodash": "^4.17.11",
     "openapi-types": "^1.3.4",
+    "query-string": "^6.5.0",
     "swagger-parser": "^6.0.5"
   },
   "devDependencies": {
@@ -49,9 +49,9 @@
     "@types/lodash": "^4.14.121",
     "@types/node": "^10.12.29",
     "@types/swagger-parser": "^4.0.3",
+    "axios-mock-adapter": "^1.16.0",
     "jest": "^23.6.0",
     "markdown-toc": "^1.2.0",
-    "openapi-backend": "^2.1.0",
     "prettier": "^1.16.4",
     "source-map-support": "^0.5.10",
     "ts-jest": "^23.10.5",

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -244,20 +244,6 @@ describe('OpenAPIClientAxios', () => {
       expect(client.defaults.baseURL).toBe(baseURL);
     });
 
-    test("query('getPets') calls GET /pets", async () => {
-      const api = new OpenAPIClientAxios({ definition, strict: true });
-      const client = await api.init();
-
-      const mock = new MockAdapter(api.client);
-      const mockResponse = [{ id: 1, name: 'Garfield' }];
-      const mockHandler = jest.fn((config) => [200, mockResponse]);
-      mock.onGet('/pets').reply((config) => mockHandler(config));
-
-      const res = await client.query('getPets');
-      expect(res.data).toEqual(mockResponse);
-      expect(mockHandler).toBeCalled();
-    });
-
     test('getPets() calls GET /pets', async () => {
       const api = new OpenAPIClientAxios({ definition, strict: true });
       const client = await api.init();
@@ -282,7 +268,7 @@ describe('OpenAPIClientAxios', () => {
       mock.onGet('/pets').reply((config) => mockHandler(config));
 
       const params = { q: 'cats ' };
-      const res = await client.getPets({ params });
+      const res = await client.getPets(params);
       expect(res.data).toEqual(mockResponse);
       expect(mockHandler).toBeCalled();
       const mockContext = mockHandler.mock.calls[mockHandler.mock.calls.length - 1][0];
@@ -299,7 +285,7 @@ describe('OpenAPIClientAxios', () => {
       mock.onGet('/pets').reply((config) => mockHandler(config));
 
       const params = { q: ['cats', 'dogs'] };
-      const res = await client.getPets({ params });
+      const res = await client.getPets(params);
       expect(res.data).toEqual(mockResponse);
       expect(mockHandler).toBeCalled();
       const mockContext = mockHandler.mock.calls[mockHandler.mock.calls.length - 1][0];
@@ -334,20 +320,6 @@ describe('OpenAPIClientAxios', () => {
       expect(mockHandler).toBeCalled();
     });
 
-    test("query('getPetById', 1) calls GET /pets/1", async () => {
-      const api = new OpenAPIClientAxios({ definition, strict: true });
-      const client = await api.init();
-
-      const mock = new MockAdapter(api.client);
-      const mockResponse = { id: 1, name: 'Garfield' };
-      const mockHandler = jest.fn((config) => [200, mockResponse]);
-      mock.onGet('/pets/1').reply((config) => mockHandler(config));
-
-      const res = await client.query('getPetById', 1);
-      expect(res.data).toEqual(mockResponse);
-      expect(mockHandler).toBeCalled();
-    });
-
     test('getPetById(1) calls GET /pets/1', async () => {
       const api = new OpenAPIClientAxios({ definition, strict: true });
       const client = await api.init();
@@ -362,23 +334,6 @@ describe('OpenAPIClientAxios', () => {
       expect(mockHandler).toBeCalled();
     });
 
-    test("query('createPet', pet) calls POST /pets with JSON payload", async () => {
-      const api = new OpenAPIClientAxios({ definition, strict: true });
-      const client = await api.init();
-
-      const mock = new MockAdapter(api.client);
-      const pet = { name: 'Garfield' };
-      const mockResponse = { id: 1, ...pet };
-      const mockHandler = jest.fn((config) => [201, mockResponse]);
-      mock.onPost('/pets').reply((config) => mockHandler(config));
-
-      const res = await client.query('createPet', pet);
-      expect(res.data).toEqual(mockResponse);
-      expect(mockHandler).toBeCalled();
-      const mockContext = mockHandler.mock.calls[mockHandler.mock.calls.length - 1][0];
-      expect(mockContext.data).toEqual(JSON.stringify(pet));
-    });
-
     test('createPet(pet) calls POST /pets with JSON payload', async () => {
       const api = new OpenAPIClientAxios({ definition, strict: true });
       const client = await api.init();
@@ -389,24 +344,7 @@ describe('OpenAPIClientAxios', () => {
       const mockHandler = jest.fn((config) => [201, mockResponse]);
       mock.onPost('/pets').reply((config) => mockHandler(config));
 
-      const res = await client.createPet(pet);
-      expect(res.data).toEqual(mockResponse);
-      expect(mockHandler).toBeCalled();
-      const mockContext = mockHandler.mock.calls[mockHandler.mock.calls.length - 1][0];
-      expect(mockContext.data).toEqual(JSON.stringify(pet));
-    });
-
-    test("query('replacePetById', 1, pet) calls PUT /pets/1 with JSON payload", async () => {
-      const api = new OpenAPIClientAxios({ definition, strict: true });
-      const client = await api.init();
-
-      const mock = new MockAdapter(api.client);
-      const pet = { id: 1, name: 'Garfield' };
-      const mockResponse = pet;
-      const mockHandler = jest.fn((config) => [200, mockResponse]);
-      mock.onPut('/pets/1').reply((config) => mockHandler(config));
-
-      const res = await client.replacePetById(1, pet);
+      const res = await client.createPet(null, pet);
       expect(res.data).toEqual(mockResponse);
       expect(mockHandler).toBeCalled();
       const mockContext = mockHandler.mock.calls[mockHandler.mock.calls.length - 1][0];
@@ -466,7 +404,7 @@ describe('OpenAPIClientAxios', () => {
       const mockHandler = jest.fn((config) => [200, mockResponse]);
       mock.onGet('/pets/1/owner/2').reply((config) => mockHandler(config));
 
-      const res = await client.getPetOwner([1, 2]);
+      const res = await client.getPetOwner({ petId: 1, ownerId: 2 });
       expect(res.data).toEqual(mockResponse);
       expect(mockHandler).toBeCalled();
     });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -34,11 +34,6 @@ const ownerId: OpenAPIV3.ParameterObject = {
   },
 };
 
-const examplePet = {
-  id: 1,
-  name: 'Garfield',
-};
-
 const definition: OpenAPIV3.Document = {
   openapi: '3.0.0',
   info: {

--- a/src/client.ts
+++ b/src/client.ts
@@ -246,7 +246,7 @@ export class OpenAPIClientAxios {
     const headers = {} as RequestConfig['headers'];
     const cookies = {} as RequestConfig['cookies'];
 
-    const setRequestParam = (name: string, value: any, type: ParamType) => {
+    const setRequestParam = (name: string, value: any, type: ParamType | string) => {
       switch (type) {
         case ParamType.Path:
           pathParams[name] = value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { OpenAPIClientAxios } from './client';
 export default OpenAPIClientAxios;
+export * from 'axios';
 export * from './client';
 export * from './types/client';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 import { OpenAPIClientAxios } from './client';
 export default OpenAPIClientAxios;
 export * from './client';
+export * from './types/client';

--- a/src/typegen.test.ts
+++ b/src/typegen.test.ts
@@ -1,0 +1,43 @@
+import path from 'path';
+import ts from 'typescript';
+import { generateTypesForDocument } from './typegen';
+
+const rootDir = path.join(__dirname, '..');
+const testsDir = path.join(rootDir, '__tests__');
+
+const examplePetAPIYAML = path.join(testsDir, 'resources', 'example-pet-api.openapi.yml');
+
+describe('typegen', () => {
+  let imports: string;
+  let schemaTypes: string;
+  let operationTypings: string;
+
+  beforeAll(async () => {
+    const types = await generateTypesForDocument(examplePetAPIYAML);
+    imports = types[0];
+    schemaTypes = types[1];
+    operationTypings = types[2];
+  });
+
+  test('generates type files from valid v3 specification', async () => {
+    expect(imports).not.toBeFalsy();
+    expect(schemaTypes).not.toBeFalsy();
+    expect(operationTypings).not.toBeFalsy();
+  });
+
+  test('exports OperationMethods', async () => {
+    expect(operationTypings).toMatch('export interface OperationMethods');
+    expect(operationTypings).toMatch('getPets');
+    expect(operationTypings).toMatch('createPet');
+    expect(operationTypings).toMatch('getPetById');
+    expect(operationTypings).toMatch('replacePetById');
+    expect(operationTypings).toMatch('updatePetById');
+    expect(operationTypings).toMatch('deletePetById');
+    expect(operationTypings).toMatch('getHumanByPetId');
+    expect(operationTypings).toMatch('getPetsMeta');
+  });
+
+  test('exports a Client', async () => {
+    expect(operationTypings).toMatch('export type Client =');
+  });
+});

--- a/src/typegen.ts
+++ b/src/typegen.ts
@@ -1,0 +1,108 @@
+import _ from 'lodash';
+import yargs from 'yargs';
+import Consumer from '.';
+import indent from 'indent-string';
+import DtsGenerator from '@anttiviljami/dtsgenerator/dist/core/dtsGenerator';
+import { parseSchema } from '@anttiviljami/dtsgenerator/dist/core/jsonSchema';
+import ReferenceResolver from '@anttiviljami/dtsgenerator/dist/core/referenceResolver';
+import SchemaConvertor, { ExportedType } from '@anttiviljami/dtsgenerator/dist/core/schemaConvertor';
+import WriteProcessor from '@anttiviljami/dtsgenerator/dist/core/writeProcessor';
+import { Document } from './types/client';
+
+export async function main() {
+  const argv = yargs
+    .usage('Usage: $0 [file]')
+    .example('$0 ./openapi.yml > client.d.ts', '- generate a type definition file')
+    .demandCommand(1).argv;
+  const [imports, schemaTypes, operationTypings] = await generateTypesForDocument(argv._[0]);
+  console.log(imports, '\n');
+  console.log(schemaTypes);
+  console.log(operationTypings);
+}
+
+export async function generateTypesForDocument(definition: Document | string) {
+  const api = new Consumer({ definition });
+  await api.init();
+
+  const processor = new WriteProcessor({ indentSize: 2, indentChar: ' ' });
+  const resolver = new ReferenceResolver();
+  const convertor = new SchemaConvertor(processor);
+  resolver.registerSchema(parseSchema(api.document));
+
+  const generator = new DtsGenerator(resolver, convertor);
+  const schemaTypes = await generator.generate();
+  const exportedTypes = convertor.getExports();
+  const operationTypings = generateOperationMethodTypings(api, exportedTypes);
+
+  const imports = [
+    'import {',
+    '  OpenAPIClient,',
+    '  Parameters,',
+    '  UnknownParamsObject,',
+    '  OperationResponse,',
+    '  AxiosRequestConfig,',
+    `} from 'openapi-client-axios';`,
+  ].join('\n');
+
+  return [imports, schemaTypes, operationTypings];
+}
+
+export function generateOperationMethodTypings(api: Consumer, exportTypes: ExportedType[]) {
+  const operations = api.getOperations();
+
+  const operationTypings = operations.map(({ operationId, summary, description }) => {
+    // parameters arg
+    const parameterTypePaths = _.chain([
+      _.find(exportTypes, { schemaRef: `#/paths/${operationId}/pathParameters` }),
+      _.find(exportTypes, { schemaRef: `#/paths/${operationId}/queryParameters` }),
+      _.find(exportTypes, { schemaRef: `#/paths/${operationId}/headerParameters` }),
+      _.find(exportTypes, { schemaRef: `#/paths/${operationId}/cookieParameters` }),
+    ])
+      .filter()
+      .map('path')
+      .value();
+    const parametersType = !_.isEmpty(parameterTypePaths) ? parameterTypePaths.join(' & ') : 'UnknownParamsObject';
+    const parametersArg = `parameters?: Parameters<${parametersType}>`;
+
+    // payload arg
+    const requestBodyType = _.find(exportTypes, { schemaRef: `#/paths/${operationId}/requestBody` });
+    const dataArg = `data?: ${requestBodyType ? requestBodyType.path : 'any'}`;
+
+    // return type
+    const responseTypePaths = _.chain(exportTypes)
+      .filter(({ schemaRef }) => schemaRef.startsWith(`#/paths/${operationId}/responses`))
+      .map('path')
+      .value();
+    const responseType = !_.isEmpty(responseTypePaths) ? responseTypePaths.join(' | ') : 'any';
+    const returnType = `OperationResponse<${responseType}>`;
+
+    const operationArgs = [parametersArg, dataArg, 'config?: AxiosRequestConfig'];
+    const operationMethod = `${operationId}(\n${operationArgs
+      .map((arg) => indent(arg, 2))
+      .join(',\n')}  \n): ${returnType}`;
+
+    // comment for type
+    const content = _.filter([summary, description]).join('\n\n');
+    const comment =
+      '/**\n' +
+      indent(content === '' ? operationId : `${operationId} - ${content}`, 1, {
+        indent: ' * ',
+        includeEmptyLines: true,
+      }) +
+      '\n */';
+
+    return [comment, operationMethod].join('\n');
+  });
+
+  return [
+    'export interface OperationMethods {',
+    ...operationTypings.map((op) => indent(op, 2)),
+    '}',
+    '',
+    'export type Client = OpenAPIClient<OperationMethods>',
+  ].join('\n');
+}
+
+if (require.main === module) {
+  main();
+}

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,0 +1,77 @@
+import { AxiosResponse, AxiosRequestConfig, AxiosInstance } from 'axios';
+import { OpenAPIV3 } from 'openapi-types';
+export * from 'openapi-types';
+
+/**
+ * Type alias for OpenAPI document. We only support v3
+ */
+export type Document = OpenAPIV3.Document;
+
+/**
+ * OpenAPI allowed HTTP methods
+ */
+export enum HttpMethod {
+  Get = 'get',
+  Put = 'put',
+  Post = 'post',
+  Patch = 'patch',
+  Delete = 'delete',
+  Options = 'options',
+  Head = 'head',
+  Trace = 'trace',
+}
+
+/**
+ * OpenAPI parameters "in"
+ */
+export enum ParamType {
+  Query = 'query',
+  Header = 'header',
+  Path = 'path',
+  Cookie = 'cookie',
+}
+
+/**
+ * Operation method spec
+ */
+export type ImplicitParamValue = string | number;
+export interface ExplicitParamValue {
+  value: string | number;
+  name: string;
+  in?: ParamType;
+}
+export interface ParamsObject {
+  [parameter: string]: ImplicitParamValue | ImplicitParamValue[];
+}
+export type ParamsArray = ExplicitParamValue[];
+export type SingleParam = ImplicitParamValue;
+export type Parameters = ParamsObject | ParamsArray | SingleParam;
+export type RequestPayload = any; // should we type this?
+export type OperationMethodArguments = [Parameters?, RequestPayload?, AxiosRequestConfig?];
+export type OperationMethod<Response> = (...args: OperationMethodArguments) => Promise<AxiosResponse<Response>>;
+export interface UnknownOperationMethods {
+  [operationId: string]: OperationMethod<any>;
+}
+
+/**
+ * Generic request config object
+ */
+export interface RequestConfig {
+  method: HttpMethod; // HTTP method
+  url: string; // full URL including protocol, host, path and query string
+  path: string; // path for the operation (relative to server base URL)
+  pathParams: { [key: string]: string }; // path parameters
+  query: { [key: string]: string | string[] }; // query parameters
+  queryString: string; // query string
+  headers: { [header: string]: string | string[] }; // HTTP headers, including cookie
+  cookies: { [cookie: string]: string }; // cookies
+  payload?: RequestPayload; // the request payload passed as-is
+}
+
+/**
+ * Operation object extended with path and method for easy looping
+ */
+export interface Operation extends OpenAPIV3.OperationObject {
+  path: string;
+  method: HttpMethod;
+}

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -38,7 +38,7 @@ export type ImplicitParamValue = string | number;
 export interface ExplicitParamValue {
   value: string | number;
   name: string;
-  in?: ParamType;
+  in?: ParamType | string;
 }
 export interface ParamsObject {
   [parameter: string]: ImplicitParamValue | ImplicitParamValue[];

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -1,4 +1,4 @@
-import { AxiosResponse, AxiosRequestConfig, AxiosInstance } from 'axios';
+import { AxiosResponse, AxiosRequestConfig } from 'axios';
 import { OpenAPIV3 } from 'openapi-types';
 export * from 'openapi-types';
 
@@ -40,17 +40,18 @@ export interface ExplicitParamValue {
   name: string;
   in?: ParamType | string;
 }
-export interface ParamsObject {
+export interface UnknownParamsObject {
   [parameter: string]: ImplicitParamValue | ImplicitParamValue[];
 }
 export type ParamsArray = ExplicitParamValue[];
 export type SingleParam = ImplicitParamValue;
-export type Parameters = ParamsObject | ParamsArray | SingleParam;
+export type Parameters<ParamsObject> = ParamsObject | ParamsArray | SingleParam;
 export type RequestPayload = any; // should we type this?
-export type OperationMethodArguments = [Parameters?, RequestPayload?, AxiosRequestConfig?];
-export type OperationMethod<Response> = (...args: OperationMethodArguments) => Promise<AxiosResponse<Response>>;
+export type OperationMethodArguments = [Parameters<UnknownParamsObject>?, RequestPayload?, AxiosRequestConfig?];
+export type OperationResponse<Response> = Promise<AxiosResponse<Response>>;
+export type UnknownOperationMethod = (...args: OperationMethodArguments) => OperationResponse<any>;
 export interface UnknownOperationMethods {
-  [operationId: string]: OperationMethod<any>;
+  [operationId: string]: UnknownOperationMethod;
 }
 
 /**

--- a/src/types/jsonSchemaDraft04.d.ts
+++ b/src/types/jsonSchemaDraft04.d.ts
@@ -1,0 +1,83 @@
+declare namespace JsonSchemaOrg {
+    namespace Draft04 {
+        /**
+         * Core schema meta-schema
+         */
+        export interface Schema {
+            id?: string; // uri
+            $schema?: string; // uri
+            $ref?: string; // uri
+            title?: string;
+            description?: string;
+            example?: string;
+            default?: any;
+            nullable?: boolean;
+            multipleOf?: number;
+            maximum?: number;
+            exclusiveMaximum?: boolean;
+            minimum?: number;
+            exclusiveMinimum?: boolean;
+            maxLength?: Schema.Definitions.PositiveInteger;
+            minLength?: Schema.Definitions.PositiveIntegerDefault0;
+            pattern?: string; // regex
+            additionalItems?: boolean | Schema;
+            items?: Schema | Schema.Definitions.SchemaArray;
+            maxItems?: Schema.Definitions.PositiveInteger;
+            minItems?: Schema.Definitions.PositiveIntegerDefault0;
+            uniqueItems?: boolean;
+            maxProperties?: Schema.Definitions.PositiveInteger;
+            minProperties?: Schema.Definitions.PositiveIntegerDefault0;
+            required?: Schema.Definitions.StringArray;
+            additionalProperties?: boolean | Schema;
+            definitions?: {
+                [name: string]: Schema;
+            };
+            properties?: {
+                [name: string]: Schema;
+            };
+            patternProperties?: {
+                [name: string]: Schema;
+            };
+            dependencies?: {
+                [name: string]: Schema | Schema.Definitions.StringArray;
+            };
+            enum?: any[];
+            type?: Schema.Definitions.SimpleTypes | Schema.Definitions.SimpleTypes[];
+            format?: string;
+            allOf?: Schema.Definitions.SchemaArray;
+            anyOf?: Schema.Definitions.SchemaArray;
+            oneOf?: Schema.Definitions.SchemaArray;
+            not?: Schema;
+        }
+        namespace Schema {
+            namespace Definitions {
+                export type PositiveInteger = number;
+                export type PositiveIntegerDefault0 = number;
+                export type SchemaArray = Schema[];
+                export type SimpleTypes = "array" | "boolean" | "integer" | "null" | "number" | "object" | "string" | "any" | "undefined";
+                export type StringArray = string[];
+            }
+            namespace Properties {
+                export type Default = any;
+                export type Description = string;
+                export type Enum = any[];
+                export type ExclusiveMaximum = boolean;
+                export type ExclusiveMinimum = boolean;
+                export type MaxItems = Definitions.PositiveInteger;
+                export type MaxLength = Definitions.PositiveInteger;
+                export type MaxProperties = Definitions.PositiveInteger;
+                export type Maximum = number;
+                export type MinItems = Definitions.PositiveIntegerDefault0;
+                export type MinLength = Definitions.PositiveIntegerDefault0;
+                export type MinProperties = Definitions.PositiveIntegerDefault0;
+                export type Minimum = number;
+                export type MultipleOf = number;
+                export type Pattern = string; // regex
+                export type Required = Definitions.StringArray;
+                export type Title = string;
+                export type Type = Definitions.SimpleTypes | Definitions.SimpleTypes[];
+                export type UniqueItems = boolean;
+            }
+        }
+    }
+}

--- a/src/types/jsonSchemaDraft07.d.ts
+++ b/src/types/jsonSchemaDraft07.d.ts
@@ -1,0 +1,79 @@
+declare namespace JsonSchemaOrg {
+  namespace Draft07 {
+    export type SchemaObject = {
+      $id?: string; // uri-reference
+      $schema?: string; // uri
+      $ref?: string; // uri-reference
+      $comment?: string;
+      title?: string;
+      description?: string;
+      default?: any;
+      nullable?: boolean;
+      readOnly?: boolean;
+      examples?: any[];
+      multipleOf?: number;
+      maximum?: number;
+      exclusiveMaximum?: number;
+      minimum?: number;
+      exclusiveMinimum?: number;
+      maxLength?: Schema.Definitions.NonNegativeInteger;
+      minLength?: Schema.Definitions.NonNegativeIntegerDefault0;
+      pattern?: string; // regex
+      additionalItems?: Schema;
+      items?: Schema | Schema.Definitions.SchemaArray;
+      maxItems?: Schema.Definitions.NonNegativeInteger;
+      minItems?: Schema.Definitions.NonNegativeIntegerDefault0;
+      uniqueItems?: boolean;
+      contains?: Schema;
+      maxProperties?: Schema.Definitions.NonNegativeInteger;
+      minProperties?: Schema.Definitions.NonNegativeIntegerDefault0;
+      required?: Schema.Definitions.StringArray;
+      additionalProperties?: Schema;
+      definitions?: {
+        [name: string]: Schema;
+      };
+      properties?: {
+        [name: string]: Schema;
+      };
+      patternProperties?: {
+        [name: string]: Schema;
+      };
+      dependencies?: {
+        [name: string]: Schema | Schema.Definitions.StringArray;
+      };
+      propertyNames?: Schema;
+      const?: any;
+      enum?: any[];
+      type?: Schema.Definitions.SimpleTypes | Schema.Definitions.SimpleTypes[];
+      format?: string;
+      contentMediaType?: string;
+      contentEncoding?: string;
+      if?: Schema;
+      then?: Schema;
+      else?: Schema;
+      allOf?: Schema.Definitions.SchemaArray;
+      anyOf?: Schema.Definitions.SchemaArray;
+      oneOf?: Schema.Definitions.SchemaArray;
+      not?: Schema;
+    };
+    export type Schema = SchemaObject | boolean;
+    namespace Schema {
+      namespace Definitions {
+        export type NonNegativeInteger = number;
+        export type NonNegativeIntegerDefault0 = number;
+        export type SchemaArray = Schema[];
+        export type SimpleTypes =
+          | 'array'
+          | 'boolean'
+          | 'integer'
+          | 'null'
+          | 'number'
+          | 'object'
+          | 'string'
+          | 'any'
+          | 'undefined';
+        export type StringArray = string[];
+      }
+    }
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,13 +15,7 @@
     "rootDir": "src/",
     "outDir": "",
     "sourceMap": true,
-    "declaration": true,
-    "paths": {
-      "*": [
-        "node_modules/*",
-        "src/types/*"
-      ]
-    }
+    "declaration": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
Breaking changes:

- Slightly different API for operation methods. #5 
- Removed the unnecessary `.query(operationId)` method
- Removed native mocking support (you can still mock using axios mock adapters)

New stuff:

- Added typegen script to generate .d.ts files for clients from OpenAPI definition files
- Moved types away from the client.ts class file