### PR TITLE
Implement paths dictionary for operations

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -386,6 +386,26 @@ const requestConfig = {
 }
 ```
 
+## Paths Dictionary
+
+In addition to operationIds, OpenAPIClient also allows calling operation
+methods, using the operations' path and HTTP method.
+
+The paths dictionary contains each path found in the OAS definition as keys,
+and an object with each registered operation method as the value.
+
+Example:
+
+```javascript
+client.paths['/pets'].get(); // GET /pets, same as calling client.getPets()
+client.paths['/pets'].post(); // POST /pets
+client.paths['/pets/{petId}'].put(1); // PUT /pets/1
+client.paths['/pets/{petId}/owner/{ownerId}'].get({ petId: 1, ownerId: 2 }) ; // GET /pets/1/owner/2
+```
+
+This allows calling operation methods without using their operationIds, which
+may be sometimes preferred.
+
 ## Typegen
 
 `openapi-client-axios` comes with a tool called `typegen` to generate typescript type files (.d.ts) for

--- a/README.md
+++ b/README.md
@@ -146,6 +146,23 @@ override axios request config parameters, such as `headers`, `timeout`, `withCre
 client.createUser(null, { user: 'admin', pass: '123' }, { headers: { 'x-api-key': 'secret' } });
 ```
 
+## Paths Dictionary
+
+OpenAPI Client Axios also allows calling API operations via their path and HTTP
+method, using the paths dictionary.
+
+Example:
+
+```javascript
+client.paths['/pets'].get(); // GET /pets, same as calling client.getPets()
+client.paths['/pets'].post(); // POST /pets
+client.paths['/pets/{petId}'].put(1); // PUT /pets/1
+client.paths['/pets/{petId}/owner/{ownerId}'].get({ petId: 1, ownerId: 2 }) ; // GET /pets/1/owner/2
+```
+
+This allows calling operation methods without using their operationIds, which
+may be sometimes preferred.
+
 ## Generating type files (.d.ts)
 
 ![TypeScript IntelliSense](typegen/intellisense.gif)

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -311,6 +311,7 @@ describe('OpenAPIClientAxios', () => {
 
       const params = { q: 'cats ' };
       const res = await client.getPets(params);
+
       expect(res.data).toEqual(mockResponse);
       expect(mockHandler).toBeCalled();
       const mockContext = mockHandler.mock.calls[mockHandler.mock.calls.length - 1][0];

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -438,6 +438,7 @@ describe('OpenAPIClientAxios', () => {
       expect(res.data).toEqual(mockResponse);
       expect(mockHandler).toBeCalled();
     });
+
     test('getOwnerByPetId(1) calls GET /pets/1/owner', async () => {
       const api = new OpenAPIClientAxios({ definition, strict: true });
       const client = await api.init();
@@ -508,7 +509,99 @@ describe('OpenAPIClientAxios', () => {
     });
   });
 
-  describe('request config', () => {
+  describe('paths dictionary', () => {
+    test(`paths['/pets'].get() calls GET /pets`, async () => {
+      const api = new OpenAPIClientAxios({ definition, strict: true });
+      const client = await api.init();
+
+      const mock = new MockAdapter(api.client);
+      const mockResponse = [{ id: 1, name: 'Garfield' }];
+      const mockHandler = jest.fn((config) => [200, mockResponse]);
+      mock.onGet('/pets').reply((config) => mockHandler(config));
+
+      const res = await client.paths['/pets'].get();
+      expect(res.data).toEqual(mockResponse);
+      expect(mockHandler).toBeCalled();
+    });
+
+    test(`paths['/pets/{petId}'].get(1) calls GET /pets/1`, async () => {
+      const api = new OpenAPIClientAxios({ definition, strict: true });
+      const client = await api.init();
+
+      const mock = new MockAdapter(api.client);
+      const mockResponse = { id: 1, name: 'Garfield' };
+      const mockHandler = jest.fn((config) => [200, mockResponse]);
+      mock.onGet('/pets/1').reply((config) => mockHandler(config));
+
+      const res = await client.paths['/pets/{petId}'].get(1);
+      expect(res.data).toEqual(mockResponse);
+      expect(mockHandler).toBeCalled();
+    });
+
+    test(`paths['/pets'].post() calls POST /pets`, async () => {
+      const api = new OpenAPIClientAxios({ definition, strict: true });
+      const client = await api.init();
+
+      const mock = new MockAdapter(api.client);
+      const pet = { name: 'Garfield' };
+      const mockResponse = { id: 1, ...pet };
+      const mockHandler = jest.fn((config) => [201, mockResponse]);
+      mock.onPost('/pets').reply((config) => mockHandler(config));
+
+      const res = await client.paths['/pets'].post(null, pet);
+      expect(res.data).toEqual(mockResponse);
+      expect(mockHandler).toBeCalled();
+      const mockContext = mockHandler.mock.calls[mockHandler.mock.calls.length - 1][0];
+      expect(mockContext.data).toEqual(JSON.stringify(pet));
+    });
+
+    test(`paths['/pets/{petId}'].put(1) calls PUT /pets/1`, async () => {
+      const api = new OpenAPIClientAxios({ definition, strict: true });
+      const client = await api.init();
+
+      const mock = new MockAdapter(api.client);
+      const pet = { id: 1, name: 'Garfield' };
+      const mockResponse = pet;
+      const mockHandler = jest.fn((config) => [200, mockResponse]);
+      mock.onPut('/pets/1').reply((config) => mockHandler(config));
+
+      const res = await client.paths['/pets/{petId}'].put(1, pet);
+      expect(res.data).toEqual(mockResponse);
+      expect(mockHandler).toBeCalled();
+      const mockContext = mockHandler.mock.calls[mockHandler.mock.calls.length - 1][0];
+      expect(mockContext.data).toEqual(JSON.stringify(pet));
+    });
+
+    test(`paths['/pets/{petId}'].delete(1) calls DELETE /pets/1`, async () => {
+      const api = new OpenAPIClientAxios({ definition, strict: true });
+      const client = await api.init();
+
+      const mock = new MockAdapter(api.client);
+      const mockResponse = { id: 1, name: 'Garfield' };
+      const mockHandler = jest.fn((config) => [200, mockResponse]);
+      mock.onDelete('/pets/1').reply((config) => mockHandler(config));
+
+      const res = await client.paths['/pets/{petId}'].delete(1);
+      expect(res.data).toEqual(mockResponse);
+      expect(mockHandler).toBeCalled();
+    });
+
+    test('getOwnerByPetId(1) calls GET /pets/1/owner', async () => {
+      const api = new OpenAPIClientAxios({ definition, strict: true });
+      const client = await api.init();
+
+      const mock = new MockAdapter(api.client);
+      const mockResponse = { name: 'Jon' };
+      const mockHandler = jest.fn((config) => [200, mockResponse]);
+      mock.onGet('/pets/1/owner').reply((config) => mockHandler(config));
+
+      const res = await client.getOwnerByPetId(1);
+      expect(res.data).toEqual(mockResponse);
+      expect(mockHandler).toBeCalled();
+    });
+  });
+
+  describe('getRequestConfigForOperation()', () => {
     test('getPets() calls GET /pets', async () => {
       const api = new OpenAPIClientAxios({ definition, strict: true });
       const client = await api.init();

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -586,16 +586,16 @@ describe('OpenAPIClientAxios', () => {
       expect(mockHandler).toBeCalled();
     });
 
-    test('getOwnerByPetId(1) calls GET /pets/1/owner', async () => {
+    test(`paths['/pets/{petId}/owner/{ownerId}'].get({ petId: 1, ownerId: 2 }) calls GET /pets/1/owner/2`, async () => {
       const api = new OpenAPIClientAxios({ definition, strict: true });
       const client = await api.init();
 
       const mock = new MockAdapter(api.client);
       const mockResponse = { name: 'Jon' };
       const mockHandler = jest.fn((config) => [200, mockResponse]);
-      mock.onGet('/pets/1/owner').reply((config) => mockHandler(config));
+      mock.onGet('/pets/1/owner/2').reply((config) => mockHandler(config));
 
-      const res = await client.getOwnerByPetId(1);
+      const res = await client.paths['/pets/{petId}/owner/{ownerId}'].get({ petId: 1, ownerId: 2 });
       expect(res.data).toEqual(mockResponse);
       expect(mockHandler).toBeCalled();
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,16 +16,19 @@ import {
   ParamsArray,
   ParamType,
   HttpMethod,
-  PathsOperationDict,
+  UnknownPathsDictionary,
 } from './types/client';
 
 /**
  * OpenAPIClient is an AxiosInstance extended with operation methods
  */
-export type OpenAPIClient<OperationMethods = UnknownOperationMethods> = AxiosInstance &
+export type OpenAPIClient<
+  OperationMethods = UnknownOperationMethods,
+  PathsDictionary = UnknownPathsDictionary
+> = AxiosInstance &
   OperationMethods & {
     api: OpenAPIClientAxios;
-    paths: PathsOperationDict;
+    paths: PathsDictionary;
   };
 
 /**
@@ -215,7 +218,7 @@ export class OpenAPIClientAxios {
         }
         const methods = this.definition.paths[path];
         for (const m in methods) {
-          if (methods[m as HttpMethod]) {
+          if (methods[m as HttpMethod] && _.includes(Object.values(HttpMethod), m)) {
             const method = m as HttpMethod;
             const operation = _.find(this.getOperations(), { path, method });
             instance.paths[path][method] = this.createOperationMethod(operation);

--- a/src/client.ts
+++ b/src/client.ts
@@ -16,6 +16,7 @@ import {
   ParamsArray,
   ParamType,
   HttpMethod,
+  PathsOperationDict,
 } from './types/client';
 
 /**
@@ -24,6 +25,7 @@ import {
 export type OpenAPIClient<OperationMethods = UnknownOperationMethods> = AxiosInstance &
   OperationMethods & {
     api: OpenAPIClientAxios;
+    paths: PathsOperationDict;
   };
 
 /**
@@ -200,6 +202,25 @@ export class OpenAPIClientAxios {
       const { operationId } = operation;
       if (operationId) {
         instance[operationId] = this.createOperationMethod(operation);
+      }
+    }
+
+    // create paths dictionary
+    // Example: api.paths['/pets/{id}'].get({ id: 1 });
+    instance.paths = {};
+    for (const path in this.definition.paths) {
+      if (this.definition.paths[path]) {
+        if (!instance.paths[path]) {
+          instance.paths[path] = {};
+        }
+        const methods = this.definition.paths[path];
+        for (const m in methods) {
+          if (methods[m as HttpMethod]) {
+            const method = m as HttpMethod;
+            const operation = _.find(this.getOperations(), { path, method });
+            instance.paths[path][method] = this.createOperationMethod(operation);
+          }
+        }
       }
     }
 

--- a/src/typegen/typegen.test.ts
+++ b/src/typegen/typegen.test.ts
@@ -39,6 +39,16 @@ describe('typegen', () => {
     expect(operationTypings).toMatch('getPetsRelative');
   });
 
+  test('exports PathsDictionary', async () => {
+    expect(operationTypings).toMatch('export interface PathsDictionary');
+    expect(operationTypings).toMatch(`['/pets']`);
+    expect(operationTypings).toMatch(`['/pets/{id}']`);
+    expect(operationTypings).toMatch(`['/pets/{id}/owner']`);
+    expect(operationTypings).toMatch(`['/pets/{petId}/owner/{ownerId}']`);
+    expect(operationTypings).toMatch(`['/pets/meta']`);
+    expect(operationTypings).toMatch(`['/pets/relative']`);
+  });
+
   test('exports a Client', async () => {
     expect(operationTypings).toMatch('export type Client =');
   });

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -80,3 +80,10 @@ export interface Operation extends OpenAPIV3.OperationObject {
   path: string;
   method: HttpMethod;
 }
+
+/**
+ * A dictionary of paths and their methods
+ */
+export interface PathsOperationDict {
+  [path: string]: { [method in HttpMethod]?: UnknownOperationMethod };
+}

--- a/src/types/client.ts
+++ b/src/types/client.ts
@@ -84,6 +84,6 @@ export interface Operation extends OpenAPIV3.OperationObject {
 /**
  * A dictionary of paths and their methods
  */
-export interface PathsOperationDict {
+export interface UnknownPathsDictionary {
   [path: string]: { [method in HttpMethod]?: UnknownOperationMethod };
 }


### PR DESCRIPTION
This PR implements a new way to call operations, without using the `operationId`.

A new paths dictionary is added to the `OpenAPIClient` instance, where each entry contains the operation functions for each method.

Examples:
```
client.paths['/pets'].get(); // GET /pets
client.paths['/pets'].post(); // POST /pets
client.paths['/pets/{petId}'].put(1); // PUT /pets/1
client.paths['/pets/{petId}/owner/{ownerId}'].get({ petId: 1, ownerId: 2 }) ; // GET /pets/1/owner/2
```