### PR TITLE
simple fix to escape method names in typegen

### DIFF
--- a/src/typegen/typegen.ts
+++ b/src/typegen/typegen.ts
@@ -84,7 +84,7 @@ function generateMethodForOperation(methodName: string, operation: Operation, ex
   const returnType = `OperationResponse<${responseType}>`;
 
   const operationArgs = [parametersArg, dataArg, 'config?: AxiosRequestConfig'];
-  const operationMethod = `${methodName}(\n${operationArgs
+  const operationMethod = `'${methodName}'(\n${operationArgs
     .map((arg) => indent(arg, 2))
     .join(',\n')}  \n): ${returnType}`;
 


### PR DESCRIPTION
A stopgap solution to #26.

operationId is turned into a string instead.

A more permanent solution would be to use the same type name converter that the dtsgenerator uses for operationId's in order to sanitize both the method names and type definitions. 