### PR TITLE
Operation method names are configurable via `transformOperationName`

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -13,6 +13,7 @@
     - [Parameter: opts.validate](#parameter-optsvalidate)
     - [Parameter: opts.withServer](#parameter-optswithserver)
     - [Parameter: opts.axiosConfigDefaults](#parameter-optsaxiosconfigdefaults)
+    - [Parameter: opts.operationNameFactory](#parameter-optsoperationnamefactory)
   - [.init()](#init)
   - [.initSync()](#initsync)
   - [.getClient()](#getclient)
@@ -160,6 +161,12 @@ Type: `number`, `string` or [Server Object](https://github.com/OAI/OpenAPI-Speci
 Optional. Default axios config for the instance. Applied when instance is created.
 
 Type: [`AxiosRequestConfig`](https://github.com/axios/axios#request-config)
+
+#### Parameter: opts.operationNameFactory
+
+Optional. Override the default method name resolution strategy (default: use `operationId` as method name)
+
+Type: `(operationId: string) => string`
 
 ### .init()
 

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -31,6 +31,15 @@ describe('OpenAPIClientAxios', () => {
       checkHasOperationMethods(api.client);
     });
 
+    test('operation method names are configurable', async () => {
+      const api = new OpenAPIClientAxios({ definition, strict: true, operationNameFactory: (operation) => operation.toUpperCase() });
+      await api.init();
+
+      expect(api.client).toHaveProperty('GETPETS');
+      expect(api.client).toHaveProperty('CREATEPET');
+      expect(api.client).toHaveProperty('GETPETBYID');
+    })
+
     test('dereferences the input document', async () => {
       const api = new OpenAPIClientAxios({ definition, strict: true });
       await api.init();

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -32,7 +32,7 @@ describe('OpenAPIClientAxios', () => {
     });
 
     test('operation method names are configurable', async () => {
-      const api = new OpenAPIClientAxios({ definition, strict: true, operationNameFactory: (operation) => operation.toUpperCase() });
+      const api = new OpenAPIClientAxios({ definition, strict: true, transformOperationName: (operation) => operation.toUpperCase() });
       await api.init();
 
       expect(api.client).toHaveProperty('GETPETS');

--- a/src/client.ts
+++ b/src/client.ts
@@ -78,7 +78,6 @@ export class OpenAPIClientAxios {
    */
   constructor(opts: {
     definition: Document | string;
-    operationNameFactory?: (operation: string) => string;
     strict?: boolean;
     quick?: boolean;
     validate?: boolean;
@@ -86,6 +85,7 @@ export class OpenAPIClientAxios {
     swaggerParserOpts?: SwaggerParser.Options;
     withServer?: number | string | Server;
     baseURLVariables?: { [key: string]: string | number };
+    operationNameFactory?: (operation: string) => string;
   }) {
     const optsWithDefaults = {
       validate: true,

--- a/src/client.ts
+++ b/src/client.ts
@@ -63,6 +63,8 @@ export class OpenAPIClientAxios {
   private defaultServer: number | string | Server;
   private baseURLVariables: { [key: string]: string | number };
 
+  private operationNameFactory: (operation: string) => string;
+
   /**
    * Creates an instance of OpenAPIClientAxios.
    *
@@ -76,6 +78,7 @@ export class OpenAPIClientAxios {
    */
   constructor(opts: {
     definition: Document | string;
+    operationNameFactory?: (operation: string) => string;
     strict?: boolean;
     quick?: boolean;
     validate?: boolean;
@@ -91,6 +94,7 @@ export class OpenAPIClientAxios {
       withServer: 0,
       baseURLVariables: {},
       swaggerParserOpts: {} as SwaggerParser.Options,
+      operationNameFactory: (operationId: string) => operationId,
       ...opts,
       axiosConfigDefaults: {
         paramsSerializer: (params) => QueryString.stringify(params, { arrayFormat: 'none' }),
@@ -105,6 +109,7 @@ export class OpenAPIClientAxios {
     this.swaggerParserOpts = optsWithDefaults.swaggerParserOpts;
     this.defaultServer = optsWithDefaults.withServer;
     this.baseURLVariables = optsWithDefaults.baseURLVariables;
+    this.operationNameFactory = optsWithDefaults.operationNameFactory;
   }
 
   /**
@@ -254,7 +259,7 @@ export class OpenAPIClientAxios {
     for (const operation of operations) {
       const { operationId } = operation;
       if (operationId) {
-        instance[operationId] = this.createOperationMethod(operation);
+        instance[this.operationNameFactory(operationId)] = this.createOperationMethod(operation);
       }
     }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -63,7 +63,7 @@ export class OpenAPIClientAxios {
   private defaultServer: number | string | Server;
   private baseURLVariables: { [key: string]: string | number };
 
-  private operationNameFactory: (operation: string) => string;
+  private transformOperationName: (operation: string) => string;
 
   /**
    * Creates an instance of OpenAPIClientAxios.
@@ -85,7 +85,7 @@ export class OpenAPIClientAxios {
     swaggerParserOpts?: SwaggerParser.Options;
     withServer?: number | string | Server;
     baseURLVariables?: { [key: string]: string | number };
-    operationNameFactory?: (operation: string) => string;
+    transformOperationName?: (operation: string) => string;
   }) {
     const optsWithDefaults = {
       validate: true,
@@ -94,7 +94,7 @@ export class OpenAPIClientAxios {
       withServer: 0,
       baseURLVariables: {},
       swaggerParserOpts: {} as SwaggerParser.Options,
-      operationNameFactory: (operationId: string) => operationId,
+      transformOperationName: (operationId: string) => operationId,
       ...opts,
       axiosConfigDefaults: {
         paramsSerializer: (params) => QueryString.stringify(params, { arrayFormat: 'none' }),
@@ -109,7 +109,7 @@ export class OpenAPIClientAxios {
     this.swaggerParserOpts = optsWithDefaults.swaggerParserOpts;
     this.defaultServer = optsWithDefaults.withServer;
     this.baseURLVariables = optsWithDefaults.baseURLVariables;
-    this.operationNameFactory = optsWithDefaults.operationNameFactory;
+    this.transformOperationName = optsWithDefaults.transformOperationName;
   }
 
   /**
@@ -259,7 +259,7 @@ export class OpenAPIClientAxios {
     for (const operation of operations) {
       const { operationId } = operation;
       if (operationId) {
-        instance[this.operationNameFactory(operationId)] = this.createOperationMethod(operation);
+        instance[this.transformOperationName(operationId)] = this.createOperationMethod(operation);
       }
     }
 

--- a/src/typegen/typegen.test.ts
+++ b/src/typegen/typegen.test.ts
@@ -13,7 +13,9 @@ describe('typegen', () => {
   let operationTypings: string;
 
   beforeAll(async () => {
-    const types = await generateTypesForDocument(examplePetAPIYAML);
+    const types = await generateTypesForDocument(examplePetAPIYAML, {
+      transformOperationName: (operationId: string) => operationId
+    });
     imports = types[0];
     schemaTypes = types[1];
     operationTypings = types[2];

--- a/src/typegen/typegen.ts
+++ b/src/typegen/typegen.ts
@@ -10,18 +10,46 @@ import WriteProcessor from '@anttiviljami/dtsgenerator/dist/core/writeProcessor'
 import SwaggerParser from 'swagger-parser';
 import { normalizeTypeName } from '@anttiviljami/dtsgenerator/dist/core/typeNameConvertor';
 
+interface TypegenOptions {
+  transformOperationName?: (operation: string) => string;
+}
+
 export async function main() {
   const argv = yargs
+    .option('transformOperationName', {
+      type: 'string'
+    })
     .usage('Usage: $0 [file]')
     .example('$0 ./openapi.yml > client.d.ts', '- generate a type definition file')
     .demandCommand(1).argv;
-  const [imports, schemaTypes, operationTypings] = await generateTypesForDocument(argv._[0]);
+
+  const opts: TypegenOptions = {
+    transformOperationName: (operation: string) => operation
+  }
+
+  if (argv.transformOperationName) {
+    const [modulePath, func] = argv.transformOperationName.split(/\.(?=[^\.]+$)/);
+
+    if (!modulePath || !func) {
+      throw new Error('transformOperationName must be provided in {path-to-module}.{exported-function} format');
+    }
+
+    const module = (await import(modulePath))
+
+    if (!module[func]) {
+      throw new Error(`Could not find transform function ${func} in ${modulePath}`);
+    }
+
+    opts.transformOperationName = module[func];
+  }
+
+  const [imports, schemaTypes, operationTypings] = await generateTypesForDocument(argv._[0], opts);
   console.log(imports, '\n');
   console.log(schemaTypes);
   console.log(operationTypings);
 }
 
-export async function generateTypesForDocument(definition: Document | string) {
+export async function generateTypesForDocument(definition: Document | string, opts: TypegenOptions) {
   const api = new OpenAPIClientAxios({ definition });
   await api.init();
 
@@ -35,7 +63,7 @@ export async function generateTypesForDocument(definition: Document | string) {
   const generator = new DtsGenerator(resolver, convertor);
   const schemaTypes = await generator.generate();
   const exportedTypes = convertor.getExports();
-  const operationTypings = generateOperationMethodTypings(api, exportedTypes);
+  const operationTypings = generateOperationMethodTypings(api, exportedTypes, opts);
 
   const imports = [
     'import {',
@@ -104,10 +132,10 @@ function generateMethodForOperation(methodName: string, operation: Operation, ex
   return [comment, operationMethod].join('\n');
 }
 
-export function generateOperationMethodTypings(api: OpenAPIClientAxios, exportTypes: ExportedType[]) {
+export function generateOperationMethodTypings(api: OpenAPIClientAxios, exportTypes: ExportedType[], opts: TypegenOptions) {
   const operations = api.getOperations();
 
-  const operationTypings = operations.map((op) => generateMethodForOperation(op.operationId, op, exportTypes));
+  const operationTypings = operations.map((op) => generateMethodForOperation(opts.transformOperationName(op.operationId), op, exportTypes));
 
   const pathOperationTypes = _.entries(api.definition.paths).map(([path, pathItem]) => {
     const methodTypings: string[] = [];

--- a/src/typegen/typegen.ts
+++ b/src/typegen/typegen.ts
@@ -17,15 +17,15 @@ interface TypegenOptions {
 export async function main() {
   const argv = yargs
     .option('transformOperationName', {
-      type: 'string'
+      type: 'string',
     })
     .usage('Usage: $0 [file]')
     .example('$0 ./openapi.yml > client.d.ts', '- generate a type definition file')
     .demandCommand(1).argv;
 
   const opts: TypegenOptions = {
-    transformOperationName: (operation: string) => operation
-  }
+    transformOperationName: (operation: string) => operation,
+  };
 
   if (argv.transformOperationName) {
     const [modulePath, func] = argv.transformOperationName.split(/\.(?=[^\.]+$)/);
@@ -34,7 +34,7 @@ export async function main() {
       throw new Error('transformOperationName must be provided in {path-to-module}.{exported-function} format');
     }
 
-    const module = (await import(modulePath))
+    const module = await import(modulePath);
 
     if (!module[func]) {
       throw new Error(`Could not find transform function ${func} in ${modulePath}`);
@@ -78,6 +78,7 @@ export async function generateTypesForDocument(definition: Document | string, op
   return [imports, schemaTypes, operationTypings];
 }
 
+// tslint:disable-next-line:max-line-length
 function generateMethodForOperation(methodName: string, operation: Operation, exportTypes: ExportedType[]) {
   const { operationId, summary, description } = operation;
 
@@ -132,10 +133,13 @@ function generateMethodForOperation(methodName: string, operation: Operation, ex
   return [comment, operationMethod].join('\n');
 }
 
+// tslint:disable-next-line:max-line-length
 export function generateOperationMethodTypings(api: OpenAPIClientAxios, exportTypes: ExportedType[], opts: TypegenOptions) {
   const operations = api.getOperations();
 
-  const operationTypings = operations.map((op) => generateMethodForOperation(opts.transformOperationName(op.operationId), op, exportTypes));
+  const operationTypings = operations.map((op) => {
+    return generateMethodForOperation(opts.transformOperationName(op.operationId), op, exportTypes);
+  });
 
   const pathOperationTypes = _.entries(api.definition.paths).map(([path, pathItem]) => {
     const methodTypings: string[] = [];


### PR DESCRIPTION
Related: #30 

Hello!

💁‍♀️ This PR allows users to override the default strategy for mapping `operationId` to methods on the OpenAPI Client.

In an API I work on, we have an OpenAPI specification that uses `operationId` that follow a convention that captures controller and action (e.g. `produce.getVegetables`, `produce.getFruits`, etc.) We use `express-openapi-validator` to enforce our specification on an Express server.

In #30, we discussed an opportunity to allow method names to be derived from `operationId` through a user-configurable "name factory", which would decide how `operationId` is mapped to method names on the client. Here it is!

Given the following simple OpenAPI specification:

<details>
<summary>openapi.yaml</summary>

```yaml
openapi: 3.0.0
info:
  title: User Configurable Operation Names
  version: '1.0'
servers:
  - url: 'http://localhost:3000'
paths:
  /fruits:
    get:
      summary: Your GET endpoint
      tags: []
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                type: array
                items:
                  type: string
      operationId: produce.getFruits
  /vegetables:
    get:
      summary: Your GET endpoint
      tags: []
      responses:
        '200':
          description: OK
          content:
            application/json:
              schema:
                type: array
                items:
                  type: string
      operationId: produce.getVegetables
components:
  schemas: {}
```

</details>

We want to access our endpoints via `client.getFruits()` or `client.getVegetables()`. However, today, we would be forced to access these via `client['produce.getFruits']()` and `client['produce.getVegetables']()`. With the addition of this PR, we will be able to do the following!

```javascript
(async () => {
  const OpenAPIClientAxios = require('openapi-client-axios').default

  const api = new OpenAPIClientAxios({ 
    definition: 'http://localhost:3000/openapi.yml',
    operationNameFactory: (operationId) => {
      const [controller, action] = operationId.split('.')
      return action
    }
  })

  api.init()

  const client = await api.getClient()

  console.log((await client.getFruits()).data)
  console.log((await client.getVegetables()).data)
})()
```

**Remaining work**

* I believe I'll need to do something in `typegen`, but haven't played around with that at all yet. It loooooooks like it pulls a configured client and grabs operations of it, so I assume (without digging in) it won't have to have knowledge of this configurable mapping. It would just trust what's already there. I may be completely wrong though; I honestly haven't looked.
* There may be additional tests we want to write. I added a test that basically uppercases the `operationId` from the specification fixtures and verify that the appropriate methods are added. Please let me know if there are any additional cases you would like me to test for.