### PR TITLE
replaced deprecated openapi-schema-validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -719,7 +719,6 @@
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.0.tgz",
       "integrity": "sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==",
-      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2003,14 +2002,12 @@
     "fast-deep-equal": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-      "dev": true
+      "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -4139,8 +4136,7 @@
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
@@ -4156,16 +4152,6 @@
       "requires": {
         "minimist": "^1.2.5"
       }
-    },
-    "jsonschema": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.2.4.tgz",
-      "integrity": "sha512-lz1nOH69GbsVHeVgEdvyavc/33oymY1AZwtePMiMj4HZPMbP5OIKK3zT9INMWjwua/V4Z4yq7wSlBbSG+g4AEw=="
-    },
-    "jsonschema-draft4": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/jsonschema-draft4/-/jsonschema-draft4-1.0.0.tgz",
-      "integrity": "sha1-8K8gBQVPDwrefqIRhhS2ncUS2GU="
     },
     "jsprim": {
       "version": "1.4.1",
@@ -4313,6 +4299,11 @@
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
       "dev": true
+    },
+    "lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -4815,13 +4806,14 @@
         "wrappy": "1"
       }
     },
-    "openapi-schema-validation": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/openapi-schema-validation/-/openapi-schema-validation-0.4.2.tgz",
-      "integrity": "sha512-K8LqLpkUf2S04p2Nphq9L+3bGFh/kJypxIG2NVGKX0ffzT4NQI9HirhiY6Iurfej9lCu7y4Ndm4tv+lm86Ck7w==",
+    "openapi-schema-validator": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-7.0.1.tgz",
+      "integrity": "sha512-P/dmF14xWbyaFVcoS1Fs2tUP4AhJO+eEnZV+jbApeo3569/Z2fiki6Mb6Rs7cfi0ewNnV4L4HiYH+HPZaKWnjQ==",
       "requires": {
-        "jsonschema": "1.2.4",
-        "jsonschema-draft4": "^1.0.0",
+        "ajv": "^6.5.2",
+        "lodash.merge": "^4.6.1",
+        "openapi-types": "^7.0.1",
         "swagger-schema-official": "2.0.0-bab6bed"
       }
     },
@@ -5081,8 +5073,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qs": {
       "version": "6.5.2",
@@ -6214,7 +6205,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
       }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "axios": "^0.20.0",
     "bath-es5": "^3.0.3",
     "lodash": "^4.17.15",
-    "openapi-schema-validation": "^0.4.2",
+    "openapi-schema-validator": "^7.0.1",
     "openapi-types": "^7.0.1",
     "query-string": "^6.5.0",
     "swagger-parser": "^10.0.2"

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,6 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig, Method } from 'axios';
 import bath from 'bath-es5';
-import { validate as validateOpenAPI } from 'openapi-schema-validation';
 import SwaggerParser from 'swagger-parser';
 import RefParser from '@apidevtools/json-schema-ref-parser';
 import dereference from '@apidevtools/json-schema-ref-parser/lib/dereference';
@@ -26,6 +25,11 @@ import {
   UnknownPathsDictionary,
   Server,
 } from './types/client';
+
+const OpenAPISchemaValidator = require('openapi-schema-validator').default;
+const validateOpenAPI = new OpenAPISchemaValidator({
+  version: 3,
+});
 
 /**
  * OpenAPIClient is an AxiosInstance extended with operation methods
@@ -289,8 +293,8 @@ export class OpenAPIClientAxios {
    * @memberof OpenAPIClientAxios
    */
   public validateDefinition = () => {
-    const { valid, errors } = validateOpenAPI(this.document, 3);
-    if (!valid) {
+    const { errors } = validateOpenAPI.validate(this.document);
+    if (errors.length) {
       const prettyErrors = JSON.stringify(errors, null, 2);
       throw new Error(`Document is not valid OpenAPI. ${errors.length} validation errors:\n${prettyErrors}`);
     }

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosRequestConfig, Method } from 'axios';
+import OpenAPISchemaValidator from 'openapi-schema-validator';
 import bath from 'bath-es5';
 import SwaggerParser from 'swagger-parser';
 import RefParser from '@apidevtools/json-schema-ref-parser';
@@ -25,11 +26,6 @@ import {
   UnknownPathsDictionary,
   Server,
 } from './types/client';
-
-const OpenAPISchemaValidator = require('openapi-schema-validator').default;
-const validateOpenAPI = new OpenAPISchemaValidator({
-  version: 3,
-});
 
 /**
  * OpenAPIClient is an AxiosInstance extended with operation methods
@@ -293,6 +289,7 @@ export class OpenAPIClientAxios {
    * @memberof OpenAPIClientAxios
    */
   public validateDefinition = () => {
+    const validateOpenAPI = new OpenAPISchemaValidator({version: 3});
     const { errors } = validateOpenAPI.validate(this.document);
     if (errors.length) {
       const prettyErrors = JSON.stringify(errors, null, 2);


### PR DESCRIPTION
`openapi-schema-validation` has been replaced
You can find the message here https://www.npmjs.com/package/openapi-schema-validation

Updated the code to use `openapi-schema-validator`.

Came across this problem while using `openapi-client-axios-typegen`. openapi-schema-validation has an unused `fs` import which breaks certain webpack builds.