### PR TITLE
Fix initSync undocomented usage of dereference method [#55]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,9 +69,9 @@
       }
     },
     "@apidevtools/json-schema-ref-parser": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.6.tgz",
-      "integrity": "sha512-M3YgsLjI0lZxvrpeGVk9Ap032W6TPQkH6pRAZz81Ac3WUNF79VQooAFnp8umjvVzUmD93NkogxEwbSce7qMsUg==",
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-9.0.7.tgz",
+      "integrity": "sha512-QdwOGF1+eeyFh+17v2Tz626WX0nucd1iKOm6JUTUvCZdbolblCOOQCxGrQPY0f7jEhn36PiAWqZnsC2r5vmUWg==",
       "requires": {
         "@jsdevtools/ono": "^7.1.3",
         "call-me-maybe": "^1.0.1",

--- a/src/client.ts
+++ b/src/client.ts
@@ -4,6 +4,7 @@ import bath from 'bath-es5';
 import SwaggerParser from 'swagger-parser';
 import RefParser from '@apidevtools/json-schema-ref-parser';
 import dereference from '@apidevtools/json-schema-ref-parser/lib/dereference';
+import $RefParserOptions from '@apidevtools/json-schema-ref-parser/lib/options';
 import QueryString from 'query-string';
 import get from 'lodash/get';
 import find from 'lodash/find';
@@ -229,7 +230,7 @@ export class OpenAPIClientAxios {
     const parser = new RefParser();
     parser.parse(this.definition);
     parser.schema = this.definition;
-    dereference(parser); // mutates this.definition (synchronous)
+    dereference(parser, new $RefParserOptions({})); // mutates this.definition (synchronous)
 
     // create axios instance
     this.instance = this.createAxiosInstance();

--- a/src/types/json-schema-ref-parser.d.ts
+++ b/src/types/json-schema-ref-parser.d.ts
@@ -1,1 +1,19 @@
-declare module '@apidevtools/json-schema-ref-parser/lib/dereference';
+declare module '@apidevtools/json-schema-ref-parser/lib/dereference' {
+  import $RefParserOptions from '@apidevtools/json-schema-ref-parser/lib/options';
+  import RefParser from '@apidevtools/json-schema-ref-parser';
+
+  export default function dereference(api: RefParser, options: $RefParserOptions): string;
+}
+
+declare module '@apidevtools/json-schema-ref-parser/lib/options' {
+  import { Options } from '@apidevtools/json-schema-ref-parser/lib';
+
+  type OptionsRequired = { [K in keyof Options]-?: Options[K] };
+
+  interface $RefParserOptions extends OptionsRequired {}
+  class $RefParserOptions {
+    constructor(options: object | Options);
+  }
+
+  export = $RefParserOptions;
+}


### PR DESCRIPTION
* Bump `@apidevtools/json-schema-ref-parser` lock from **9.0.6** to **9.0.7**
* Describe `dereference` method and `$RefParserOptions` from `json-schema-ref-parser` library, for a future error preventing at type-check stage
* Fix incorrect `dereference` method usage, `options` argument are **not marked as optional** in orig documentation and should b always passed (with default values)