### PR TITLE
Ability to add defaultParameters

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -154,6 +154,29 @@ Type: `(operationId: string) => string`
 
 For typegen: You can pass the `transformOperationName` using the `-t` ot `--transformOperationName` command line flag.
 
+#### Parameter: opts.transformOperationMethod
+
+Optional. Transforms the returned operation method (default: do not transform)
+
+Type: `(operationMethod: UnknownOperationMethod, operationToTransform: Operation) => UnknownOperationMethod`
+
+The `operation` is also provided to the function, such that you can also conditionally transform the method.
+
+Example:
+
+```javascript
+const api = new OpenAPIClientAxios({ 
+  definition: 'https://example.com/api/openapi.json',
+  transformOperationMethods: (operationMethod, operation) => {
+    return (params, body, config) => {
+      // set default workspaceId for all operations
+      params.workspaceId = '63e90965-07a7-43b3-8f5d-d2e8fa90e8d0';
+      return operationMethod(params, body, config);
+    }
+  }
+});
+```
+
 ### .init()
 
 Initalizes OpenAPIClientAxios

--- a/README.md
+++ b/README.md
@@ -171,50 +171,6 @@ client.paths['/pets/{petId}/owner/{ownerId}'].get({ petId: 1, ownerId: 2 }) ; //
 This allows calling operation methods without using their operationIds, which
 may be sometimes preferred.
 
-## Transforming operation name
-
-The client also allows transforming the operation names obtained from the Open API definition. This is done by providing 
-a transformation function. 
-
-```javascript
-import OpenAPIClientAxios from 'openapi-client-axios';
-
-const api = new OpenAPIClientAxios({ 
-  definition: 'https://example.com/api/openapi.json',
-  transformOperationName: (operationName) => `${operationName}V1`});
-api.init();
-
-async function createPet() {
-  const client = await api.getClient();
-  const res = await client.createPetV1(null, { name: 'Garfield' });
-  console.log('Pet created', res.data);
-}
-```
-
-## Transforming operation method
-
-It is also possible to transform the operation method and the arguments that are provided. This allows you for example
-to provide default parameters, or even to override the implementation of the method. This is again executed with a
-transformation function.
-
-The `operation` is also provided to the function, such that you can also conditionally transform the method. 
-
-```javascript
-import OpenAPIClientAxios from 'openapi-client-axios';
-
-const api = new OpenAPIClientAxios({ 
-  definition: 'https://example.com/api/openapi.json',
-  transformOperationMethods: (operationMethod, operation) => {
-    return (params, body, config) => {
-      // set default workspaceId for all operations
-      params.workspaceId = '63e90965-07a7-43b3-8f5d-d2e8fa90e8d0';
-      return operationMethod(params, body, config);
-    }
-  }
-});
-api.init();
-```
-
 ## Generating type files (.d.ts)
 
 ![TypeScript IntelliSense](typegen/intellisense.gif)

--- a/README.md
+++ b/README.md
@@ -171,6 +171,50 @@ client.paths['/pets/{petId}/owner/{ownerId}'].get({ petId: 1, ownerId: 2 }) ; //
 This allows calling operation methods without using their operationIds, which
 may be sometimes preferred.
 
+## Transforming operation name
+
+The client also allows transforming the operation names obtained from the Open API definition. This is done by providing 
+a transformation function. 
+
+```javascript
+import OpenAPIClientAxios from 'openapi-client-axios';
+
+const api = new OpenAPIClientAxios({ 
+  definition: 'https://example.com/api/openapi.json',
+  transformOperationName: (operationName) => `${operationName}V1`});
+api.init();
+
+async function createPet() {
+  const client = await api.getClient();
+  const res = await client.createPetV1(null, { name: 'Garfield' });
+  console.log('Pet created', res.data);
+}
+```
+
+## Transforming operation method
+
+It is also possible to transform the operation method and the arguments that are provided. This allows you for example
+to provide default parameters, or even to override the implementation of the method. This is again executed with a
+transformation function.
+
+The `operation` is also provided to the function, such that you can also conditionally transform the method. 
+
+```javascript
+import OpenAPIClientAxios from 'openapi-client-axios';
+
+const api = new OpenAPIClientAxios({ 
+  definition: 'https://example.com/api/openapi.json',
+  transformOperationMethods: (operationMethod, operation) => {
+    return (params, body, config) => {
+      // set default workspaceId for all operations
+      params.workspaceId = '63e90965-07a7-43b3-8f5d-d2e8fa90e8d0';
+      return operationMethod(params, body, config);
+    }
+  }
+});
+api.init();
+```
+
 ## Generating type files (.d.ts)
 
 ![TypeScript IntelliSense](typegen/intellisense.gif)

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -645,4 +645,71 @@ describe('OpenAPIClientAxios', () => {
       expect(mockHandler).toBeCalled();
     });
   });
+
+  describe('transforms', () => {
+    test('transformOperationName', async () => {
+      const api = new OpenAPIClientAxios({
+        definition,
+        transformOperationName: (operationName) => `${operationName}V1`,
+      });
+      const client = await api.init();
+
+      const mock = new MockAdapter(api.client);
+      const mockResponse = { name: 'Jon' };
+      const mockHandler = jest.fn((config) => [200, mockResponse]);
+      mock.onGet('/pets/1/owner/2').reply((config) => mockHandler(config));
+
+      const res = await client.getPetOwnerV1({ petId: 1, ownerId: 2 });
+      expect(res.data).toEqual(mockResponse);
+      expect(mockHandler).toBeCalled();
+    });
+  });
+
+  test('transformOperationMethod', async () => {
+    const api = new OpenAPIClientAxios({
+      definition,
+      'transformOperationMethods': (operationMethod ) => {
+        return (params: any, body, config) => {
+          params['petId'] = 1;
+          params['ownerId'] = 2;
+          return operationMethod(params, body, config);
+        };
+      },
+    });
+    const client = await api.init();
+
+    const mock = new MockAdapter(api.client);
+    const mockResponse = { name: 'Jon' };
+    const mockHandler = jest.fn((config) => [200, mockResponse]);
+    mock.onGet('/pets/1/owner/2').reply((config) => mockHandler(config));
+
+    const res = await client.getPetOwner({});
+    expect(res.data).toEqual(mockResponse);
+    expect(mockHandler).toBeCalled();
+  });
+
+  test('transformOperationMethod based on operation', async () => {
+    const api = new OpenAPIClientAxios({
+      definition,
+      transformOperationMethods: (operationMethod, operation) => {
+        return (params: any, body, config) => {
+          if (operation.operationId === 'getPetOwner') {
+            params['petId'] = 1;
+            params['ownerId'] = 2;
+          }
+          return operationMethod(params, body, config);
+        };
+      },
+    });
+    const client = await api.init();
+
+    const mock = new MockAdapter(api.client);
+    const mockResponse = { name: 'Jon' };
+    const mockHandler = jest.fn((config) => [200, mockResponse]);
+    mock.onGet('/pets/1/owner/2').reply((config) => mockHandler(config));
+
+    const res = await client.getPetOwner({});
+    expect(res.data).toEqual(mockResponse);
+    expect(mockHandler).toBeCalled();
+  });
 });

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -668,7 +668,7 @@ describe('OpenAPIClientAxios', () => {
   test('transformOperationMethod', async () => {
     const api = new OpenAPIClientAxios({
       definition,
-      'transformOperationMethods': (operationMethod ) => {
+      'transformOperationMethod': (operationMethod ) => {
         return (params: any, body, config) => {
           params['petId'] = 1;
           params['ownerId'] = 2;
@@ -691,7 +691,7 @@ describe('OpenAPIClientAxios', () => {
   test('transformOperationMethod based on operation', async () => {
     const api = new OpenAPIClientAxios({
       definition,
-      transformOperationMethods: (operationMethod, operation) => {
+      transformOperationMethod: (operationMethod, operation) => {
         return (params: any, body, config) => {
           if (operation.operationId === 'getPetOwner') {
             params['petId'] = 1;

--- a/src/client.ts
+++ b/src/client.ts
@@ -62,7 +62,7 @@ export class OpenAPIClientAxios {
   private baseURLVariables: { [key: string]: string | number };
 
   private transformOperationName: (operation: string) => string;
-  private transformOperationMethods: (operationMethod: UnknownOperationMethod, operationToTransform: Operation)
+  private transformOperationMethod: (operationMethod: UnknownOperationMethod, operationToTransform: Operation)
     => UnknownOperationMethod;
 
   /**
@@ -82,7 +82,7 @@ export class OpenAPIClientAxios {
     withServer?: number | string | Server;
     baseURLVariables?: { [key: string]: string | number };
     transformOperationName?: (operation: string) => string;
-    transformOperationMethods?: (operationMethod: UnknownOperationMethod, operationToTransform: Operation)
+    transformOperationMethod?: (operationMethod: UnknownOperationMethod, operationToTransform: Operation)
       => UnknownOperationMethod;
   }) {
     const optsWithDefaults = {
@@ -91,7 +91,7 @@ export class OpenAPIClientAxios {
       baseURLVariables: {},
       swaggerParserOpts: {} as RefParser.Options,
       transformOperationName: (operationId: string) => operationId,
-      transformOperationMethods:
+      transformOperationMethod:
         (operationMethod: UnknownOperationMethod) => operationMethod,
       ...opts,
       axiosConfigDefaults: {
@@ -106,7 +106,7 @@ export class OpenAPIClientAxios {
     this.defaultServer = optsWithDefaults.withServer;
     this.baseURLVariables = optsWithDefaults.baseURLVariables;
     this.transformOperationName = optsWithDefaults.transformOperationName;
-    this.transformOperationMethods = optsWithDefaults.transformOperationMethods;
+    this.transformOperationMethod = optsWithDefaults.transformOperationMethod;
   }
 
   /**
@@ -547,6 +547,6 @@ export class OpenAPIClientAxios {
       return this.client.request(axiosConfig);
     };
 
-    return this.transformOperationMethods(originalOperationMethod, operation);
+    return this.transformOperationMethod(originalOperationMethod, operation);
   };
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -63,8 +63,6 @@ export class OpenAPIClientAxios {
 
   private transformOperationName: (operation: string) => string;
 
-  private defaultParameters: any;
-
   /**
    * Creates an instance of OpenAPIClientAxios.
    *
@@ -82,7 +80,6 @@ export class OpenAPIClientAxios {
     withServer?: number | string | Server;
     baseURLVariables?: { [key: string]: string | number };
     transformOperationName?: (operation: string) => string;
-    defaultParameters?: any;
   }) {
     const optsWithDefaults = {
       quick: false,
@@ -90,14 +87,12 @@ export class OpenAPIClientAxios {
       baseURLVariables: {},
       swaggerParserOpts: {} as RefParser.Options,
       transformOperationName: (operationId: string) => operationId,
-      defaultParameters: {},
       ...opts,
       axiosConfigDefaults: {
         paramsSerializer: (params) => QueryString.stringify(params, { arrayFormat: 'none' }),
         ...(opts.axiosConfigDefaults || {}),
       } as AxiosRequestConfig,
     };
-
     this.inputDocument = optsWithDefaults.definition;
     this.quick = optsWithDefaults.quick;
     this.axiosConfigDefaults = optsWithDefaults.axiosConfigDefaults;
@@ -105,7 +100,6 @@ export class OpenAPIClientAxios {
     this.defaultServer = optsWithDefaults.withServer;
     this.baseURLVariables = optsWithDefaults.baseURLVariables;
     this.transformOperationName = optsWithDefaults.transformOperationName;
-    this.defaultParameters = optsWithDefaults.defaultParameters;
   }
 
   /**
@@ -442,21 +436,6 @@ export class OpenAPIClientAxios {
         return firstParam;
       }
     };
-
-    // add in default parameters
-    if (isArray(this.defaultParameters)) {
-      // ParamsArray
-      for (const param of this.defaultParameters) {
-        setRequestParam(param.name, param.value, param.in || getParamType(param.name));
-      }
-    } else if (typeof this.defaultParameters === 'object') {
-      // ParamsObject
-      for (const name in this.defaultParameters) {
-        if (this.defaultParameters[name] !== undefined) {
-          setRequestParam(name, this.defaultParameters[name], getParamType(name));
-        }
-      }
-    }
 
     const [paramsArg, payload] = args;
     if (isArray(paramsArg)) {

--- a/src/client.ts
+++ b/src/client.ts
@@ -62,6 +62,8 @@ export class OpenAPIClientAxios {
   private baseURLVariables: { [key: string]: string | number };
 
   private transformOperationName: (operation: string) => string;
+  private transformOperationMethods: (operationMethod: UnknownOperationMethod, operationToTransform: Operation)
+    => UnknownOperationMethod;
 
   /**
    * Creates an instance of OpenAPIClientAxios.
@@ -80,6 +82,8 @@ export class OpenAPIClientAxios {
     withServer?: number | string | Server;
     baseURLVariables?: { [key: string]: string | number };
     transformOperationName?: (operation: string) => string;
+    transformOperationMethods?: (operationMethod: UnknownOperationMethod, operationToTransform: Operation)
+      => UnknownOperationMethod;
   }) {
     const optsWithDefaults = {
       quick: false,
@@ -87,6 +91,8 @@ export class OpenAPIClientAxios {
       baseURLVariables: {},
       swaggerParserOpts: {} as RefParser.Options,
       transformOperationName: (operationId: string) => operationId,
+      transformOperationMethods:
+        (operationMethod: UnknownOperationMethod) => operationMethod,
       ...opts,
       axiosConfigDefaults: {
         paramsSerializer: (params) => QueryString.stringify(params, { arrayFormat: 'none' }),
@@ -100,6 +106,7 @@ export class OpenAPIClientAxios {
     this.defaultServer = optsWithDefaults.withServer;
     this.baseURLVariables = optsWithDefaults.baseURLVariables;
     this.transformOperationName = optsWithDefaults.transformOperationName;
+    this.transformOperationMethods = optsWithDefaults.transformOperationMethods;
   }
 
   /**
@@ -534,10 +541,12 @@ export class OpenAPIClientAxios {
    * @memberof OpenAPIClientAxios
    */
   private createOperationMethod = (operation: Operation): UnknownOperationMethod => {
-    return async (...args: OperationMethodArguments) => {
+    const originalOperationMethod = async (...args: OperationMethodArguments) => {
       const axiosConfig = this.getAxiosConfigForOperation(operation, args);
       // do the axios request
       return this.client.request(axiosConfig);
     };
+
+    return this.transformOperationMethods(originalOperationMethod, operation);
   };
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -63,6 +63,8 @@ export class OpenAPIClientAxios {
 
   private transformOperationName: (operation: string) => string;
 
+  private defaultParameters: any;
+
   /**
    * Creates an instance of OpenAPIClientAxios.
    *
@@ -80,6 +82,7 @@ export class OpenAPIClientAxios {
     withServer?: number | string | Server;
     baseURLVariables?: { [key: string]: string | number };
     transformOperationName?: (operation: string) => string;
+    defaultParameters?: any;
   }) {
     const optsWithDefaults = {
       quick: false,
@@ -87,12 +90,14 @@ export class OpenAPIClientAxios {
       baseURLVariables: {},
       swaggerParserOpts: {} as RefParser.Options,
       transformOperationName: (operationId: string) => operationId,
+      defaultParameters: {},
       ...opts,
       axiosConfigDefaults: {
         paramsSerializer: (params) => QueryString.stringify(params, { arrayFormat: 'none' }),
         ...(opts.axiosConfigDefaults || {}),
       } as AxiosRequestConfig,
     };
+
     this.inputDocument = optsWithDefaults.definition;
     this.quick = optsWithDefaults.quick;
     this.axiosConfigDefaults = optsWithDefaults.axiosConfigDefaults;
@@ -100,6 +105,7 @@ export class OpenAPIClientAxios {
     this.defaultServer = optsWithDefaults.withServer;
     this.baseURLVariables = optsWithDefaults.baseURLVariables;
     this.transformOperationName = optsWithDefaults.transformOperationName;
+    this.defaultParameters = optsWithDefaults.defaultParameters;
   }
 
   /**
@@ -436,6 +442,21 @@ export class OpenAPIClientAxios {
         return firstParam;
       }
     };
+
+    // add in default parameters
+    if (isArray(this.defaultParameters)) {
+      // ParamsArray
+      for (const param of this.defaultParameters) {
+        setRequestParam(param.name, param.value, param.in || getParamType(param.name));
+      }
+    } else if (typeof this.defaultParameters === 'object') {
+      // ParamsObject
+      for (const name in this.defaultParameters) {
+        if (this.defaultParameters[name] !== undefined) {
+          setRequestParam(name, this.defaultParameters[name], getParamType(name));
+        }
+      }
+    }
 
     const [paramsArg, payload] = args;
     if (isArray(paramsArg)) {


### PR DESCRIPTION
We have an API construction where we need to add in the workspaceId (like a tenant identifier) in every request in the path:
`http://server/api/<workspaceId>/do-something`

This is currently handled by passing in the workspaceId as parameter in every request, but it would be great if we can just set defaultParameters when creating an OpenAPIClient.

```
const api = new OpenAPIClientAxios({
    definition: 'http://localhost:5000/swagger/private/swagger.json',
    defaultParameters: {
        workspaceId: '63e90965-0797-4393-8f5d-d2e8fae0e8d0'
    }
});
```