### PR TITLE
fix: orthographic error on the client init method (typo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ async function createPet() {
 OpenAPI Client Axios uses [operationIds](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#operation-object)
 in OpenAPIv3 definitions to call API operations.
 
-After initalizing `OpenAPIClientAxios`, an axios client instance extended with OpenAPI capabilities is exposed.
+After initializing `OpenAPIClientAxios`, an axios client instance extended with OpenAPI capabilities is exposed.
 
 Example:
 ```javascript
@@ -80,7 +80,7 @@ api.init().then((client) => {
 });
 ```
 
-`client` is an [axios instance](https://github.com/axios/axios#creating-an-instance) initalized with
+`client` is an [axios instance](https://github.com/axios/axios#creating-an-instance) initialized with
 baseURL from OpenAPI definitions and extended with extra operation methods for calling API operations.
 
 It also has a reference to OpenAPIClientAxios at `client.api`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "openapi-client-axios",
-  "version": "3.14.1",
+  "version": "4.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.14.1",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@apidevtools/json-schema-ref-parser": "^9.0.7",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openapi-client-axios",
   "description": "JavaScript client library for consuming OpenAPI-enabled APIs with axios. Types included.",
-  "version": "3.14.1",
+  "version": "4.0.0",
   "author": "Viljami Kuosmanen <viljami@viljami.io>",
   "license": "MIT",
   "keywords": [

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -26,7 +26,7 @@ describe('OpenAPIClientAxios', () => {
     test('can be initalised with a valid OpenAPI document as JS Object', async () => {
       const api = new OpenAPIClientAxios({ definition });
       await api.init();
-      expect(api.initalized).toEqual(true);
+      expect(api.initialized).toEqual(true);
       expect(api.client.api).toBe(api);
       checkHasOperationMethods(api.client);
     });
@@ -50,23 +50,23 @@ describe('OpenAPIClientAxios', () => {
       expect(JSON.stringify(api.definition)).not.toMatch('$ref');
     });
 
-    test('can be initalised using a valid YAML file', async () => {
+    test('can be initialized using a valid YAML file', async () => {
       const api = new OpenAPIClientAxios({ definition: examplePetAPIYAML });
       await api.init();
-      expect(api.initalized).toEqual(true);
+      expect(api.initialized).toEqual(true);
       expect(api.client.api).toBe(api);
       checkHasOperationMethods(api.client);
     });
 
-    test('can be initalised using a valid JSON file', async () => {
+    test('can be initialized using a valid JSON file', async () => {
       const api = new OpenAPIClientAxios({ definition: examplePetAPIJSON });
       await api.init();
-      expect(api.initalized).toEqual(true);
+      expect(api.initialized).toEqual(true);
       expect(api.client.api).toBe(api);
       checkHasOperationMethods(api.client);
     });
 
-    test('can be initalised using alternative server using index', async () => {
+    test('can be initialized using alternative server using index', async () => {
       const api = new OpenAPIClientAxios({ definition, withServer: 1 });
       await api.init();
       expect(api.getBaseURL()).toEqual(baseURLAlternative);
@@ -74,7 +74,7 @@ describe('OpenAPIClientAxios', () => {
       checkHasOperationMethods(api.client);
     });
 
-    test('can be initalised using alternative server using description', async () => {
+    test('can be initialized using alternative server using description', async () => {
       const api = new OpenAPIClientAxios({ definition, withServer: 'Alternative server' });
       await api.init();
       expect(api.getBaseURL()).toEqual(baseURLAlternative);
@@ -82,7 +82,7 @@ describe('OpenAPIClientAxios', () => {
       checkHasOperationMethods(api.client);
     });
 
-    test('can be initialised using alternative server with variable in baseURL', async () => {
+    test('can be initialized using alternative server with variable in baseURL', async () => {
       const api = new OpenAPIClientAxios({
         definition,
         withServer: 2,
@@ -94,7 +94,7 @@ describe('OpenAPIClientAxios', () => {
       checkHasOperationMethods(api.client);
     });
 
-    test('can be initalised using alternative server using object', async () => {
+    test('can be initialized using alternative server using object', async () => {
       const url = 'http://examplde.com/v5';
       const api = new OpenAPIClientAxios({ definition, withServer: { url } });
       await api.init();
@@ -103,7 +103,7 @@ describe('OpenAPIClientAxios', () => {
       checkHasOperationMethods(api.client);
     });
 
-    test('can be initalised using default baseUrl resolver', async () => {
+    test('can be initialized using default baseUrl resolver', async () => {
       const api = new OpenAPIClientAxios({ definition });
       await api.init();
       expect(api.getBaseURL()).toEqual(baseURL);
@@ -155,10 +155,10 @@ describe('OpenAPIClientAxios', () => {
   });
 
   describe('initSync', () => {
-    test('can be initalised synchronously with a valid OpenAPI document as JS Object', () => {
+    test('can be initialized synchronously with a valid OpenAPI document as JS Object', () => {
       const api = new OpenAPIClientAxios({ definition });
       api.initSync();
-      expect(api.initalized).toEqual(true);
+      expect(api.initialized).toEqual(true);
       expect(api.client.api).toBe(api);
       checkHasOperationMethods(api.client);
     });
@@ -170,7 +170,7 @@ describe('OpenAPIClientAxios', () => {
       expect(JSON.stringify(api.definition)).not.toMatch('$ref');
     });
 
-    test('throws an error when initalised using a file URL', () => {
+    test('throws an error when initialized using a file URL', () => {
       const api = new OpenAPIClientAxios({ definition: examplePetAPIYAML });
       expect(api.initSync).toThrowError();
     });

--- a/src/client.ts
+++ b/src/client.ts
@@ -52,7 +52,7 @@ export class OpenAPIClientAxios {
 
   public quick: boolean;
 
-  public initalized: boolean;
+  public initialized: boolean;
   public instance: any;
 
   public axiosConfigDefaults: AxiosRequestConfig;
@@ -120,7 +120,7 @@ export class OpenAPIClientAxios {
    * @memberof OpenAPIClientAxios
    */
   public getClient = async <Client = OpenAPIClient>(): Promise<Client> => {
-    if (!this.initalized) {
+    if (!this.initialized) {
       return this.init<Client>();
     }
     return this.instance as Client;
@@ -132,7 +132,7 @@ export class OpenAPIClientAxios {
   }
 
   /**
-   * Initalizes OpenAPIClientAxios and creates a member axios client instance
+   * Initializes OpenAPIClientAxios and creates a member axios client instance
    *
    * The init() method should be called right after creating a new instance of OpenAPIClientAxios
    *
@@ -156,8 +156,8 @@ export class OpenAPIClientAxios {
     // create axios instance
     this.instance = this.createAxiosInstance();
 
-    // we are now initalized
-    this.initalized = true;
+    // we are now initialized
+    this.initialized = true;
     return this.instance as Client;
   };
 
@@ -196,8 +196,8 @@ export class OpenAPIClientAxios {
     // create axios instance
     this.instance = this.createAxiosInstance();
 
-    // we are now initalized
-    this.initalized = true;
+    // we are now initialized
+    this.initialized = true;
     return this.instance as Client;
   };
 


### PR DESCRIPTION
**Why are you seeing this?**

We have an orthographic error on the client interface (_true story_).

```
import OpenAPIClientAxios from 'openapi-client-axios';

const api = new OpenAPIClientAxios({ definition: 'https://example.com/api/openapi.json' });
api.init();

// api.initalized  ===> api.initialized
```

**If merged then what?**

This slightly breaks the API, so I'm shipping a major (v4.0.0).
