### PR TITLE
feat: add programmatic support to type generation

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -492,3 +492,10 @@ const client = await api.getClient<PetStoreClient>();
 $ typegen ./petstore.yaml
 $ typegen https://raw.githubusercontent.com/OAI/OpenAPI-Specification/master/examples/v3.0/petstore.yaml
 ```
+
+You can also use the typegen functionality in a programmatic way! 
+```typescript
+import { generateTypesForDocument } from 'openapi-client-axios'
+
+const typesFileContent = (await generateTypesForDocument(document)).join('\n')
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export default OpenAPIClientAxios;
 export * from 'axios';
 export * from './client';
 export * from './types/client';
+export { generateTypesForDocument } from './typegen/typegen'


### PR DESCRIPTION
This patch introduces support to importing the function that uses `DTSGenerator` to create the typings for the client, in a programmatic way :]