### PR TITLE
fix(type) : Remove extra $ in responses types

### DIFF
--- a/src/typegen/typegen.test.ts
+++ b/src/typegen/typegen.test.ts
@@ -27,19 +27,34 @@ describe('typegen', () => {
     expect(operationTypings).not.toBeFalsy();
   });
 
-  test('exports OperationMethods', async () => {
-    expect(operationTypings).toMatch('export interface OperationMethods');
-    expect(operationTypings).toMatch('getPets');
-    expect(operationTypings).toMatch('createPet');
-    expect(operationTypings).toMatch('getPetById');
-    expect(operationTypings).toMatch('replacePetById');
-    expect(operationTypings).toMatch('updatePetById');
-    expect(operationTypings).toMatch('deletePetById');
-    expect(operationTypings).toMatch('getOwnerByPetId');
-    expect(operationTypings).toMatch('getPetOwner');
-    expect(operationTypings).toMatch('getPetsMeta');
-    expect(operationTypings).toMatch('getPetsRelative');
-  });
+  describe ('OperationsMethods', () => {
+    test('exports methods named after the operationId', async () => {
+      expect(operationTypings).toMatch('export interface OperationMethods');
+      expect(operationTypings).toMatch('getPets');
+      expect(operationTypings).toMatch('createPet');
+      expect(operationTypings).toMatch('getPetById');
+      expect(operationTypings).toMatch('replacePetById');
+      expect(operationTypings).toMatch('updatePetById');
+      expect(operationTypings).toMatch('deletePetById');
+      expect(operationTypings).toMatch('getOwnerByPetId');
+      expect(operationTypings).toMatch('getPetOwner');
+      expect(operationTypings).toMatch('getPetsMeta');
+      expect(operationTypings).toMatch('getPetsRelative');
+    });
+
+    test('types responses', () => {
+      expect(operationTypings).toMatch(`OperationResponse<Paths.GetPets.Responses.$200>`);
+      expect(operationTypings).toMatch('OperationResponse<Paths.CreatePet.Responses.$201>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetById.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.ReplacePetById.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.UpdatePetById.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.DeletePetById.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetOwner.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetsMeta.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetsRelative.Responses.$200>');
+    })
+  })
+
 
   test('exports PathsDictionary', async () => {
     expect(operationTypings).toMatch('export interface PathsDictionary');
@@ -54,4 +69,5 @@ describe('typegen', () => {
   test('exports a Client', async () => {
     expect(operationTypings).toMatch('export type Client =');
   });
+  
 });

--- a/src/typegen/typegen.ts
+++ b/src/typegen/typegen.ts
@@ -97,13 +97,7 @@ function generateMethodForOperation(methodName: string, operation: Operation, ex
   // return type
   const responseTypePaths = _.chain(exportTypes)
     .filter(({ schemaRef }) => schemaRef.startsWith(`#/paths/${normalizedOperationId}/responses/2`))
-    .map(({ path }) =>
-      path
-        .split('.')
-        // Operation.Responses.200 => Operation.Responses.$200
-        .map((key, i) => (i === path.split('.').length - 1 ? `$${key}` : key))
-        .join('.'),
-    )
+    .map(({ path }) => path)
     .value();
   const responseType = !_.isEmpty(responseTypePaths) ? responseTypePaths.join(' | ') : 'any';
   const returnType = `OperationResponse<${responseType}>`;


### PR DESCRIPTION
Hello ! 

Thank you very much for this library 🙏 ! [At Pennylane](https://github.com/pennylane-hq), we use it a lot to improve the communication between our frontend & backend engineers. 🎉 

Since we updated the library's version, in the `client.d.ts` file, the responses's types have been prefixed with a " $ ". 
I guess that is because the "$" is now added by the dts-generator library ?

**How to reproduce** : 
Run `./typegen ../__tests__/resources/example-pet-api.openapi.yml` and have a look at the generated ts file. You will see that each response type is something like `OperationResponse<Paths.OperationId.Responses.$$200>` .

I was wondering if you will be ok to remove the extra "$".
  I didn’t see any contributing guides, so let me know if I’ve done something wrong.

  Thanks,