### PR TITLE
Fix: single-element array params not being passed as array

### DIFF
--- a/packages/openapi-client-axios/src/client.test.ts
+++ b/packages/openapi-client-axios/src/client.test.ts
@@ -532,6 +532,18 @@ describe('OpenAPIClientAxios', () => {
       expect(config.queryString).toEqual('q=cat');
     });
 
+    test('getPets({ q: ["cat"] }) calls GET /pets?q=cat', async () => {
+      const api = new OpenAPIClientAxios({ definition });
+      const client = await api.init();
+      const config = api.getRequestConfigForOperation('getPets', [{ q: ['cat'] }]);
+
+      expect(config.method).toEqual('get');
+      expect(config.path).toEqual('/pets');
+      expect(config.url).toMatch('/pets?q=cat');
+      expect(config.query).toEqual({ q: ['cat'] });
+      expect(config.queryString).toEqual('q=cat');
+    });
+
     test('getPetById({ petId: 1 }) calls GET /pets/1', async () => {
       const api = new OpenAPIClientAxios({ definition });
       const client = await api.init();

--- a/packages/openapi-client-axios/src/client.ts
+++ b/packages/openapi-client-axios/src/client.ts
@@ -415,7 +415,7 @@ export class OpenAPIClientAxios {
           } else {
             searchParams.append(name, value);
           }
-          query[name] = value
+          query[name] = value;
           break;
         case ParamType.Header:
           headers[name] = value;

--- a/packages/openapi-client-axios/src/client.ts
+++ b/packages/openapi-client-axios/src/client.ts
@@ -397,6 +397,7 @@ export class OpenAPIClientAxios {
 
     const pathParams = {} as RequestConfig['pathParams'];
     const searchParams = new URLSearchParams();
+    const query = {} as RequestConfig['query'];
     const headers = {} as RequestConfig['headers'];
     const cookies = {} as RequestConfig['cookies'];
     const parameters = (operation.parameters || []) as ParameterObject[];
@@ -414,6 +415,7 @@ export class OpenAPIClientAxios {
           } else {
             searchParams.append(name, value);
           }
+          query[name] = value
           break;
         case ParamType.Header:
           headers[name] = value;
@@ -474,13 +476,8 @@ export class OpenAPIClientAxios {
     }
     const path = pathBuilder.path(pathParams);
 
-    // query parameters
+    // queryString parameter
     const queryString = searchParams.toString();
-    const query = {} as RequestConfig['query'];
-    for (const key of searchParams.keys()) {
-      const val = searchParams.getAll(key);
-      query[key] = val.length > 1 ? val : val[0];
-    }
 
     // full url with query string
     const url = `${this.getBaseURL(operation)}${path}${queryString ? `?${queryString}` : ''}`;


### PR DESCRIPTION
Hey @anttiviljami, 

This PR fixes https://github.com/anttiviljami/openapi-client-axios/issues/111.

I wrote a test to reproduce the issue and it's passing with these changes.

I'm not sure if this is the right way to fix it, but let me know what you think.

Thanks,
Joao