### PR TITLE
Fix uncaught error for empty operation IDs

### DIFF
--- a/packages/typegen/src/__tests__/resources/example-aws-api-gateway-rest.openapi.json
+++ b/packages/typegen/src/__tests__/resources/example-aws-api-gateway-rest.openapi.json
@@ -1,0 +1,156 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Example API with missing Operation IDs",
+    "description": "Exmaple generated from AWS API Gateway REST API, which creates option paths to support CORS; see: https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-cors.html",
+    "version": "1.0.0"
+  },
+  "tags": [
+    {
+      "name": "pets",
+      "description": "Pet operations"
+    }
+  ],
+  "servers": [
+    {
+      "url": "http://localhost:8080"
+    }
+  ],
+  "paths": {
+    "/pets": {
+      "get": {
+        "operationId": "getPets",
+        "summary": "List pets",
+        "description": "Returns all pets in database",
+        "tags": [
+          "pets"
+        ],
+        "responses": {
+          "200": {
+            "description": "List of pets in database"
+          }
+        },
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of items to return",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/QueryLimit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Starting offset for returning items",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/QueryOffset"
+            }
+          }
+        ]
+      },
+      "options": {
+        "parameters": [
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Number of items to return",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/QueryLimit"
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "description": "Starting offset for returning items",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/QueryOffset"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "204 response",
+            "headers": {
+              "Access-Control-Allow-Origin": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Methods": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Vary": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "Access-Control-Allow-Headers": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {}
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "PetId": {
+        "description": "Unique identifier for pet in database",
+        "example": 1,
+        "title": "PetId",
+        "type": "integer"
+      },
+      "PetPayload": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "description": "Name of the pet",
+            "example": "Garfield",
+            "title": "PetName",
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "name"
+        ]
+      },
+      "QueryLimit": {
+        "description": "Number of items to return",
+        "example": 25,
+        "title": "QueryLimit",
+        "type": "integer"
+      },
+      "QueryOffset": {
+        "description": "Starting offset for returning items",
+        "example": 0,
+        "title": "QueryOffset",
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "requestBodies": {
+      "PetPayload": {
+        "description": "Request payload containing a pet object",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/PetPayload"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/typegen/src/typegen-aws-api-gateway-rest.test.ts
+++ b/packages/typegen/src/typegen-aws-api-gateway-rest.test.ts
@@ -1,0 +1,67 @@
+import path from 'path';
+import { generateTypesForDocument } from './typegen';
+
+const examplePetAPIYAML = path.join(__dirname, '__tests__', 'resources', 'example-aws-api-gateway-rest.openapi.json');
+
+describe('typegen', () => {
+  let imports: string;
+  let schemaTypes: string;
+  let operationTypings: string;
+
+  beforeAll(async () => {
+    const types = await generateTypesForDocument(examplePetAPIYAML, {
+      transformOperationName: (operationId: string) => operationId,
+    });
+    imports = types[0];
+    schemaTypes = types[1];
+    operationTypings = types[2];
+  });
+
+  test('generates type files from valid v3 specification', async () => {
+    expect(imports).not.toBeFalsy();
+    expect(schemaTypes).not.toBeFalsy();
+    expect(operationTypings).not.toBeFalsy();
+  });
+
+  describe('OperationsMethods', () => {
+    test('exports methods named after the operationId', async () => {
+      expect(operationTypings).toMatch('export interface OperationMethods');
+      expect(operationTypings).toMatch('getPets');
+      expect(operationTypings).toMatch('createPet');
+      expect(operationTypings).toMatch('getPetById');
+      expect(operationTypings).toMatch('replacePetById');
+      expect(operationTypings).toMatch('updatePetById');
+      expect(operationTypings).toMatch('deletePetById');
+      expect(operationTypings).toMatch('getOwnerByPetId');
+      expect(operationTypings).toMatch('getPetOwner');
+      expect(operationTypings).toMatch('getPetsMeta');
+      expect(operationTypings).toMatch('getPetsRelative');
+    });
+
+    test('types responses', () => {
+      expect(operationTypings).toMatch(`OperationResponse<Paths.GetPets.Responses.$200>`);
+      expect(operationTypings).toMatch('OperationResponse<Paths.CreatePet.Responses.$201>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetById.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.ReplacePetById.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.UpdatePetById.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.DeletePetById.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetOwner.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetsMeta.Responses.$200>');
+      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetsRelative.Responses.$200>');
+    });
+  });
+
+  test('exports PathsDictionary', async () => {
+    expect(operationTypings).toMatch('export interface PathsDictionary');
+    expect(operationTypings).toMatch(`['/pets']`);
+    expect(operationTypings).toMatch(`['/pets/{id}']`);
+    expect(operationTypings).toMatch(`['/pets/{id}/owner']`);
+    expect(operationTypings).toMatch(`['/pets/{petId}/owner/{ownerId}']`);
+    expect(operationTypings).toMatch(`['/pets/meta']`);
+    expect(operationTypings).toMatch(`['/pets/relative']`);
+  });
+
+  test('exports a Client', async () => {
+    expect(operationTypings).toMatch('export type Client =');
+  });
+});

--- a/packages/typegen/src/typegen-aws-api-gateway-rest.test.ts
+++ b/packages/typegen/src/typegen-aws-api-gateway-rest.test.ts
@@ -3,7 +3,7 @@ import { generateTypesForDocument } from './typegen';
 
 const examplePetAPIYAML = path.join(__dirname, '__tests__', 'resources', 'example-aws-api-gateway-rest.openapi.json');
 
-describe('typegen', () => {
+describe('typegen for openapi spec with missing operation IDs', () => {
   let imports: string;
   let schemaTypes: string;
   let operationTypings: string;
@@ -27,38 +27,16 @@ describe('typegen', () => {
     test('exports methods named after the operationId', async () => {
       expect(operationTypings).toMatch('export interface OperationMethods');
       expect(operationTypings).toMatch('getPets');
-      expect(operationTypings).toMatch('createPet');
-      expect(operationTypings).toMatch('getPetById');
-      expect(operationTypings).toMatch('replacePetById');
-      expect(operationTypings).toMatch('updatePetById');
-      expect(operationTypings).toMatch('deletePetById');
-      expect(operationTypings).toMatch('getOwnerByPetId');
-      expect(operationTypings).toMatch('getPetOwner');
-      expect(operationTypings).toMatch('getPetsMeta');
-      expect(operationTypings).toMatch('getPetsRelative');
     });
 
     test('types responses', () => {
       expect(operationTypings).toMatch(`OperationResponse<Paths.GetPets.Responses.$200>`);
-      expect(operationTypings).toMatch('OperationResponse<Paths.CreatePet.Responses.$201>');
-      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetById.Responses.$200>');
-      expect(operationTypings).toMatch('OperationResponse<Paths.ReplacePetById.Responses.$200>');
-      expect(operationTypings).toMatch('OperationResponse<Paths.UpdatePetById.Responses.$200>');
-      expect(operationTypings).toMatch('OperationResponse<Paths.DeletePetById.Responses.$200>');
-      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetOwner.Responses.$200>');
-      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetsMeta.Responses.$200>');
-      expect(operationTypings).toMatch('OperationResponse<Paths.GetPetsRelative.Responses.$200>');
     });
   });
 
   test('exports PathsDictionary', async () => {
     expect(operationTypings).toMatch('export interface PathsDictionary');
     expect(operationTypings).toMatch(`['/pets']`);
-    expect(operationTypings).toMatch(`['/pets/{id}']`);
-    expect(operationTypings).toMatch(`['/pets/{id}/owner']`);
-    expect(operationTypings).toMatch(`['/pets/{petId}/owner/{ownerId}']`);
-    expect(operationTypings).toMatch(`['/pets/meta']`);
-    expect(operationTypings).toMatch(`['/pets/relative']`);
   });
 
   test('exports a Client', async () => {

--- a/packages/typegen/src/typegen.ts
+++ b/packages/typegen/src/typegen.ts
@@ -143,9 +143,13 @@ export function generateOperationMethodTypings(
 ) {
   const operations = api.getOperations();
 
-  const operationTypings = operations.map((op) => {
-    return generateMethodForOperation(opts.transformOperationName(op.operationId), op, exportTypes);
-  });
+  const operationTypings = operations
+    .map((op) => {
+      return op.operationId
+        ? generateMethodForOperation(opts.transformOperationName(op.operationId), op, exportTypes)
+        : null;
+    })
+    .filter((op) => Boolean(op));
 
   const pathOperationTypes = _.entries(api.definition.paths).map(([path, pathItem]) => {
     const methodTypings: string[] = [];
@@ -153,7 +157,10 @@ export function generateOperationMethodTypings(
       if (pathItem[m as HttpMethod] && _.includes(Object.values(HttpMethod), m)) {
         const method = m as HttpMethod;
         const operation = _.find(operations, { path, method });
-        methodTypings.push(generateMethodForOperation(method, operation, exportTypes));
+        if (operation.operationId) {
+          const methodForOperation = generateMethodForOperation(method, operation, exportTypes);
+          methodTypings.push(methodForOperation);
+        }
       }
     }
     return [`['${path}']: {`, ...methodTypings.map((m) => indent(m, 2)), '}'].join('\n');


### PR DESCRIPTION
See: #150 

Changes for review to the typegen package:
- Created: `packages/typegen/src/__tests__/resources/example-aws-api-gateway-rest.openapi.json` as an example of the type of Open API spec generated by using the GetExport method on an AWS API Gateway REST API
- Created a matching test file: `packages/typegen/src/typegen-aws-api-gateway-rest.test.ts`
- Changes to `packages/typegen/src/typegen.ts` to ignore operations that have no operationId

Failing test case error before fix - one of two caused in two separate loops to `generateMethodForOperation`:
```sh
 typegen for openapi spec with missing operation IDs › exports a Client

    TypeError: Cannot read properties of undefined (reading 'replace')

      13 | // rule from 'dts-generator' jsonSchema.ts
      14 | function convertKeyToTypeName(key: string): string {
    > 15 |   key = key.replace(/\/(.)/g, (_match: string, p1: string) => {
         |             ^
      16 |     return p1.toUpperCase();
      17 |   });
      18 |   return key

      at convertKeyToTypeName (src/typegen.ts:15:13)
      at generateMethodForOperation (src/typegen.ts:95:33)
      at src/typegen.ts:148:14
          at Array.map (<anonymous>)
      at generateOperationMethodTypings (src/typegen.ts:147:6)
      at src/typegen.ts:76:28
      at step (src/typegen.ts:52:23)
      at Object.next (src/typegen.ts:33:53)
      at fulfilled (src/typegen.ts:24:58)
  ```