### PR TITLE
Search normalized paths for parameters as well

### DIFF
--- a/packages/typegen/src/typegen.ts
+++ b/packages/typegen/src/typegen.ts
@@ -93,11 +93,16 @@ function generateMethodForOperation(methodName: string, operation: Operation, ex
 
   // parameters arg
   const normalizedOperationId = convertKeyToTypeName(operationId);
+  const normalizedPath = convertKeyToTypeName(operation.path);
   const parameterTypePaths = _.chain([
     _.find(exportTypes, { schemaRef: `#/paths/${normalizedOperationId}/pathParameters` }),
+    _.find(exportTypes, { schemaRef: `#/paths/${normalizedPath}/pathParameters` }),
     _.find(exportTypes, { schemaRef: `#/paths/${normalizedOperationId}/queryParameters` }),
+    _.find(exportTypes, { schemaRef: `#/paths/${normalizedPath}/queryParameters` }),
     _.find(exportTypes, { schemaRef: `#/paths/${normalizedOperationId}/headerParameters` }),
+    _.find(exportTypes, { schemaRef: `#/paths/${normalizedPath}/headerParameters` }),
     _.find(exportTypes, { schemaRef: `#/paths/${normalizedOperationId}/cookieParameters` }),
+    _.find(exportTypes, { schemaRef: `#/paths/${normalizedPath}/cookieParameters` }),
   ])
     .filter()
     .map('path')


### PR DESCRIPTION
Parameters can be defined for all verbs within a path at the path level in the OpenAPI spec. E.g.

```
paths:
  /user/{userId}:
    parameters:
      ....

    get: # parameters apply here as well
```

However, the typegen code wouldn't find those because it was only searching for exported types under the operationId and didn't include searches that apply to the overall path. This change adds directives to check the path-level for applicable request parameters as well.