### PR TITLE
Typo: Replace fesponse with response

### DIFF
--- a/packages/openapi-client-axios/src/client.ts
+++ b/packages/openapi-client-axios/src/client.ts
@@ -210,7 +210,7 @@ export class OpenAPIClientAxios {
         const yaml = await import('js-yaml');
         this.document = yaml.load(documentRes.data) as Document;
       } else {
-        const err = new Error(`Invalid fesponse fetching OpenAPI definition: ${documentRes}`) as any;
+        const err = new Error(`Invalid response fetching OpenAPI definition: ${documentRes}`) as any;
         err.response = documentRes;
         throw err;
       }


### PR DESCRIPTION
Yesterday i came across with this typo while using openapi-client-axios.

