### PR TITLE
Add constructor option to allow reusing an axios instance

### DIFF
--- a/packages/openapi-client-axios/src/client.ts
+++ b/packages/openapi-client-axios/src/client.ts
@@ -64,7 +64,7 @@ export type OpenAPIClientAxiosOptions = {
     operationMethod: UnknownOperationMethod,
     operationToTransform: Operation,
   ) => UnknownOperationMethod;
-  axiosRunner: (axiosConfig: AxiosRequestConfig) => Promise<AxiosResponse>;
+  axiosRunner?: (axiosConfig: AxiosRequestConfig) => Promise<AxiosResponse>;
   axiosConfigDefaults?: AxiosRequestConfig;
 } & ({
   axiosConfigDefaults?: AxiosRequestConfig;

--- a/packages/openapi-client-axios/src/client.ts
+++ b/packages/openapi-client-axios/src/client.ts
@@ -113,6 +113,7 @@ export class OpenAPIClientAxios {
    * @param {boolean} opts.quick - quick mode, skips validation and doesn't guarantee document is unchanged
    * @param {boolean} opts.applyMethodCommonHeaders Should method (patch / post / put / etc.) specific default headers (from axios.defaults.headers.{method}) be applied to operation methods?
    * @param {boolean} opts.axiosConfigDefaults - default axios config for the instance
+   * @param {boolean} opts.axiosInstance - axios instance to use
    * @memberof OpenAPIClientAxios
    */
   constructor(opts: OpenAPIClientAxiosOptions) {


### PR DESCRIPTION
This is for issue #77

This adds the axiosInstance property to the constructor options. This PR also includes some refactoring and new tests.

I added this because some users want the option to reuse another axios instance. The change will make this library compatible with more libraries.

I added tests to ensure that none of the properties of the default request config are changed. This partially addresses npdev453's 2nd point in the issue thread. The baseUrl property is the only one that might be modified, but only when it's undefined.

The documentation needs to be updated to inform the user about potential problems with using the axiosInstance property. It looks like the documentation is separate from this repo, so I can't edit it, but I added the new property to the function documentation.
