### PR TITLE
test: cover empty operation security override

### DIFF
--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -803,6 +803,25 @@ describe('OpenAPIClientAxios', () => {
       const config = api.getRequestConfigForOperation('getDiscount', ['20% / 30% off']);
       expect(config.path).toEqual('/discounts/20%25%20%2F%2030%25%20off');
     });
+
+    test('operation security overrides global security with an empty list', async () => {
+      const api = new OpenAPIClientAxios({ definition: createDefinition({
+        security: [{ bearerAuth: [] }],
+        paths: {
+          '/public': {
+            get: {
+              operationId: 'getPublic',
+              security: [],
+              responses: { '200': { description: 'ok' } },
+            },
+          },
+        },
+      })});
+      await api.init();
+
+      const operation = api.getOperation('getPublic');
+      expect(operation?.security).toEqual([]);
+    });
   });
 
   describe('query parameter array serialization', () => {


### PR DESCRIPTION
Summary
- Adds regression coverage for operation-level `security: []` when global security exists.
- Confirms operation metadata keeps the explicit empty security override.

Validation
- git diff --check
- Full test suite not run because this temporary clone has no node_modules and the workspace has about 1 GiB free disk.
