### PR TITLE
Fix tests against axios 0.33

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,6 +3,7 @@ import type { JestConfigWithTsJest } from 'ts-jest'
 const jestConfig: JestConfigWithTsJest = {
   testEnvironment: 'node',
   testMatch: ['**/?(*.)+(spec|test).ts?(x)'],
+  setupFilesAfterEnv: ['<rootDir>/src/__tests__/setup.ts'],
   transform: {
     '^.+\\.[tj]s?$': [
       'ts-jest',

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,0 +1,18 @@
+import MockAdapter from 'axios-mock-adapter';
+import type { AxiosRequestConfig } from 'axios';
+
+/**
+ * axios >= 0.33 hardened its internal config/header merge to build null-prototype objects.
+ * axios-mock-adapter reads `config.headers.constructor.name` to detect AxiosHeaders, which
+ * throws on such objects. Hand the mock adapter a normal-prototype copy of the headers.
+ *
+ * @see https://github.com/ctimmerm/axios-mock-adapter/blob/master/src/handle_request.js
+ */
+const originalAdapter = MockAdapter.prototype.adapter;
+MockAdapter.prototype.adapter = function patchedAdapter(this: MockAdapter) {
+  const handleRequest = originalAdapter.call(this) as (config: AxiosRequestConfig) => Promise<unknown>;
+  return ((config: AxiosRequestConfig) =>
+    config.headers && Object.getPrototypeOf(config.headers) === null
+      ? handleRequest({ ...config, headers: { ...config.headers } })
+      : handleRequest(config)) as ReturnType<typeof originalAdapter>;
+};

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -281,7 +281,7 @@ describe('OpenAPIClientAxios', () => {
       expect(d.timeout).toBe(1234);
       expect(d.withCredentials).toBe(true);
       expect(d.adapter).toBe(userAdapter);
-      expect(d.auth).toStrictEqual({
+      expect(d.auth).toEqual({
         username: 'fake',
         password: 'fakepassword'
       }),
@@ -296,7 +296,7 @@ describe('OpenAPIClientAxios', () => {
       expect(d.validateStatus).toBe(userValidateStatus);
       expect(d.maxRedirects).toBe(99);
       expect(d.socketPath).toBe('/fake/path/example');
-      expect(d.proxy).toStrictEqual({
+      expect(d.proxy).toEqual({
           host: '1.2.3.4',
           port: 9876,
           auth: {


### PR DESCRIPTION
## Problem

The `0.*.*` entry in the CI matrix now resolves to **axios 0.33.0** (the 0.x line picked up 0.31–0.33 prototype-pollution hardening releases), and 30 of 69 tests fail there:

```
TypeError: Cannot read properties of undefined (reading 'name')
  at handleRequest (node_modules/axios-mock-adapter/src/handle_request.js:78:51)
```

Two distinct causes, one upstream change:

1. axios 0.33 builds `utils.merge` results with `Object.create(null)`. `dispatchRequest` runs every request's headers through that merge, so `config.headers` reaches the adapter with a null prototype — and axios-mock-adapter reads `config.headers.constructor.name === 'AxiosHeaders'`, which throws on the undefined `constructor`. The stack points at our `runRequest` line, but the fault is inside the mock adapter. axios-mock-adapter 2.1.0 has the identical check, so upgrading it does not fix this.
2. The same hardening makes `mergeConfig` hand back null-prototype `defaults.auth` and `defaults.proxy`. `toStrictEqual` compares prototypes, so it fails with "serializes to the same string" even though the values are unchanged.

The library itself behaves correctly under axios 0.33 — this is purely a test-tooling incompatibility.

## Changes

- **`src/__tests__/setup.ts`** (new) — wraps `MockAdapter.prototype.adapter` and, *only* when `config.headers` has a null prototype, passes the handler a config with a normal-prototype copy of the headers. axios 1.x and 0.25/0.30 take the untouched path, so `AxiosHeaders` detection still behaves exactly as before.
- **`jest.config.ts`** — registers the setup file via `setupFilesAfterEnv`.
- **`src/client.test.ts`** — `toStrictEqual` → `toEqual` for the two prototype-sensitive `defaults` assertions.

## Verification

`npm test` passes 69/69 on every matrix entry:

| axios | result |
| --- | --- |
| 0.25.0 (oldest supported) | 69 passed |
| 0.30.2 | 69 passed |
| 0.33.0 (latest 0.x) | 69 passed |
| 1.18.1 (`^1.0.0` / `latest`) | 69 passed |

`npm run lint` and `npm run build` are clean.

## Note

The shim exists to work around an axios-mock-adapter bug present in both 1.22.0 and 2.1.0; worth filing upstream if we want to drop it eventually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
